### PR TITLE
feat(codex): import official auth.json

### DIFF
--- a/app/src/main/java/com/kite/app/CardRunActivity.kt
+++ b/app/src/main/java/com/kite/app/CardRunActivity.kt
@@ -22,6 +22,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.kite.app.action.KiteInstallPlanActionIntent
+import com.kite.app.agent.auth.CodexAuthImportError
+import com.kite.app.agent.auth.CodexAuthJsonImporter
 import com.kite.app.application.browser.BrowserHandoffCoordinator
 import com.kite.app.application.browser.BrowserHandoffLaunchResult
 import com.kite.app.application.resources.ResourceActionEffect
@@ -85,7 +87,9 @@ import com.kite.app.ui.theme.applyKiteWindowTheme
 import com.kite.app.ui.UiKit
 import com.kite.app.ui.terminal.KiteTerminalShellTheme
 import com.kite.app.shell.TerminalSurfaceShellBinding
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /** 只托管一个运行实例及其可见显示面，不拥有首页、资源目录或底层任务生命周期。 */
 class CardRunActivity : AppCompatActivity() {
@@ -120,6 +124,31 @@ class CardRunActivity : AppCompatActivity() {
         ActivityResultContracts.OpenMultipleDocuments()
     ) { uris ->
         agentSurfaceBinding?.addAttachments(uris)
+    }
+    private val codexAuthJsonPicker = registerForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        if (uri == null) return@registerForActivityResult
+        lifecycleScope.launch {
+            val result = withContext(Dispatchers.IO) {
+                CodexAuthJsonImporter.importFromUri(this@CardRunActivity, uri)
+            }
+            if (result.success) {
+                Toast.makeText(
+                    this@CardRunActivity,
+                    getString(com.kite.app.R.string.agent_codex_auth_import_success),
+                    Toast.LENGTH_LONG,
+                ).show()
+                graph.agentOfficialAccountManager.refresh("codex", "chatgpt")
+                agentSurfaceBinding?.refreshCodexOfficialAccountStatus()
+            } else {
+                Toast.makeText(
+                    this@CardRunActivity,
+                    codexAuthImportFailureMessage(result.error),
+                    Toast.LENGTH_LONG,
+                ).show()
+            }
+        }
     }
     private val backCallback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
@@ -414,6 +443,9 @@ class CardRunActivity : AppCompatActivity() {
                 agentAttachmentPicker.launch(
                     arrayOf("text/*", "application/pdf", "application/octet-stream")
                 )
+            },
+            onPickCodexAuthJson = {
+                codexAuthJsonPicker.launch(arrayOf("application/json", "text/plain", "application/octet-stream"))
             },
             agentRegistry = graph.agentRegistry,
             officialAccountManager = graph.agentOfficialAccountManager,
@@ -982,6 +1014,17 @@ class CardRunActivity : AppCompatActivity() {
     }
 
     private fun activeEnvironmentId(): String = graph.resourceInstallStore.currentEnvironmentId()
+
+    private fun codexAuthImportFailureMessage(error: CodexAuthImportError?): String = when (error) {
+        CodexAuthImportError.INVALID_JSON -> "导入失败：不是受支持的 JSON 认证文件，或文件超过 1 MB。"
+        CodexAuthImportError.MISSING_ID_TOKEN -> "导入失败：缺少 id_token。"
+        CodexAuthImportError.MISSING_ACCESS_TOKEN -> "导入失败：缺少 access_token。"
+        CodexAuthImportError.MISSING_REFRESH_TOKEN -> "导入失败：缺少 refresh_token。"
+        CodexAuthImportError.INVALID_ID_TOKEN -> "导入失败：id_token 不是有效的 JWT。"
+        CodexAuthImportError.CONTAINER_NOT_READY -> "导入失败：默认容器尚未准备完成。"
+        CodexAuthImportError.WRITE_FAILED,
+        null -> "导入失败：无法安全写入 Codex 认证文件。"
+    }
 
     private fun targetEnvironmentId(): String = boundEnvironmentId ?: activeEnvironmentId()
 

--- a/app/src/main/java/com/kite/app/agent/auth/CodexAuthJsonImporter.kt
+++ b/app/src/main/java/com/kite/app/agent/auth/CodexAuthJsonImporter.kt
@@ -1,0 +1,407 @@
+package com.kite.app.agent.auth
+
+import android.content.Context
+import android.net.Uri
+import com.kite.app.agent.config.ContainerAgentConfigProjection
+import com.kite.app.foundation.workspace.WorkSurfaceRuntimeBridge
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.time.Instant
+import java.time.format.DateTimeParseException
+import java.util.Base64
+
+internal enum class CodexAuthImportError {
+    INVALID_JSON,
+    MISSING_ID_TOKEN,
+    MISSING_ACCESS_TOKEN,
+    MISSING_REFRESH_TOKEN,
+    INVALID_ID_TOKEN,
+    CONTAINER_NOT_READY,
+    WRITE_FAILED,
+}
+
+internal data class CodexAuthImportResult(
+    val success: Boolean,
+    val error: CodexAuthImportError? = null,
+    val authBackupCreated: Boolean = false,
+    val configBackupCreated: Boolean = false,
+    val accountLabel: String? = null,
+)
+
+/**
+ * 把官方 auth.json、CPA 单账号导出和 Sub2API accounts 导出统一成 Codex 原生凭据。
+ *
+ * 认证文件只会写入当前容器的可见/可写 PRoot View，避免直接改 Base rootfs 后活跃 View
+ * 仍然读取旧内容。导入前会备份现有文件，正文不会写入日志、异常消息或结果对象。
+ */
+internal object CodexAuthJsonImporter {
+    private const val MAX_PAYLOAD_BYTES = 1024 * 1024
+    private const val MAX_JSON_NODES = 512
+    private const val AUTH_PATH = "/root/.codex/auth.json"
+    private const val CONFIG_PATH = "/root/.codex/config.toml"
+
+    fun importFromUri(context: Context, uri: Uri): CodexAuthImportResult {
+        val payload = runCatching { readLimited(context, uri) }.getOrNull()
+            ?: return CodexAuthImportResult(false, CodexAuthImportError.INVALID_JSON)
+        return importIntoDefaultContainer(context, payload)
+    }
+
+    fun importIntoDefaultContainer(
+        context: Context,
+        payload: ByteArray,
+        now: Instant = Instant.now(),
+    ): CodexAuthImportResult {
+        if (payload.isEmpty() || payload.size > MAX_PAYLOAD_BYTES) {
+            return CodexAuthImportResult(false, CodexAuthImportError.INVALID_JSON)
+        }
+        val appContext = context.applicationContext
+        val container = WorkSurfaceRuntimeBridge.getSavedContainer(appContext)
+            ?: return CodexAuthImportResult(false, CodexAuthImportError.CONTAINER_NOT_READY)
+        val projection = ContainerAgentConfigProjection { container }
+        return runCatching {
+            val authProjection = projection.resolve(AUTH_PATH)
+                ?: return@runCatching CodexAuthImportResult(false, CodexAuthImportError.CONTAINER_NOT_READY)
+            val configProjection = projection.resolve(CONFIG_PATH)
+            importIntoFiles(
+                authFile = authProjection.writeFile,
+                authBackupSource = authProjection.readFile,
+                configFile = configProjection?.writeFile,
+                configBackupSource = configProjection?.readFile,
+                payload = payload.toString(StandardCharsets.UTF_8),
+                now = now,
+            )
+        }.getOrElse { CodexAuthImportResult(false, CodexAuthImportError.WRITE_FAILED) }
+    }
+
+    internal fun importIntoRootfs(
+        rootfsDir: File,
+        payload: String,
+        now: Instant = Instant.now(),
+    ): CodexAuthImportResult {
+        val codexDir = File(rootfsDir, "root/.codex")
+        return importIntoFiles(
+            authFile = File(codexDir, "auth.json"),
+            authBackupSource = File(codexDir, "auth.json"),
+            configFile = File(codexDir, "config.toml"),
+            configBackupSource = File(codexDir, "config.toml"),
+            payload = payload,
+            now = now,
+        )
+    }
+
+    internal fun parseCredentials(payload: String): ImportedCodexCredentials? {
+        val roots = parseRoots(payload) ?: return null
+        val objects = candidateObjects(roots)
+        for (candidate in objects) {
+            val tokenObject = candidate.optJSONObject("tokens") ?: candidate
+            val idToken = tokenObject.firstString("id_token", "idToken") ?: continue
+            val accessToken = tokenObject.firstString("access_token", "accessToken") ?: continue
+            val refreshToken = tokenObject.firstString("refresh_token", "refreshToken") ?: continue
+            val idClaims = decodeJwtClaims(idToken) ?: return null
+            val accountId = tokenObject.firstString(
+                "account_id",
+                "accountId",
+                "chatgpt_account_id",
+                "chatgptAccountId",
+            ) ?: candidate.firstString(
+                "account_id",
+                "accountId",
+                "chatgpt_account_id",
+                "chatgptAccountId",
+            ) ?: accountIdFromClaims(idClaims)
+            val lastRefresh = candidate.firstString("last_refresh", "lastRefresh")
+                ?.takeIf(::isIsoInstant)
+                ?: roots.firstNotNullOfOrNull { it.firstString("last_refresh", "lastRefresh")?.takeIf(::isIsoInstant) }
+            val email = candidate.firstString("email")
+                ?: roots.firstNotNullOfOrNull { it.firstString("email") }
+                ?: idClaims.firstString("email")
+            return ImportedCodexCredentials(
+                idToken = idToken,
+                accessToken = accessToken,
+                refreshToken = refreshToken,
+                accountId = accountId,
+                lastRefresh = lastRefresh,
+                email = email,
+            )
+        }
+        return null
+    }
+
+    internal fun parseError(payload: String): CodexAuthImportError {
+        val roots = parseRoots(payload) ?: return CodexAuthImportError.INVALID_JSON
+        val objects = candidateObjects(roots)
+        val tokenObject = objects.firstOrNull { candidate ->
+            val tokens = candidate.optJSONObject("tokens") ?: candidate
+            tokens.firstString("id_token", "idToken") != null
+        }?.let { it.optJSONObject("tokens") ?: it }
+            ?: return CodexAuthImportError.MISSING_ID_TOKEN
+        if (tokenObject.firstString("access_token", "accessToken") == null) {
+            return CodexAuthImportError.MISSING_ACCESS_TOKEN
+        }
+        if (tokenObject.firstString("refresh_token", "refreshToken") == null) {
+            return CodexAuthImportError.MISSING_REFRESH_TOKEN
+        }
+        return if (decodeJwtClaims(tokenObject.firstString("id_token", "idToken").orEmpty()) == null) {
+            CodexAuthImportError.INVALID_ID_TOKEN
+        } else {
+            CodexAuthImportError.INVALID_JSON
+        }
+    }
+
+    internal fun buildOfficialAuth(
+        credentials: ImportedCodexCredentials,
+        now: Instant,
+    ): JSONObject = JSONObject()
+        .put("auth_mode", "chatgpt")
+        .put(
+            "tokens",
+            JSONObject()
+                .put("id_token", credentials.idToken)
+                .put("access_token", credentials.accessToken)
+                .put("refresh_token", credentials.refreshToken)
+                .apply { credentials.accountId?.let { put("account_id", it) } },
+        )
+        .put("last_refresh", credentials.lastRefresh ?: now.toString())
+
+    internal fun activateBuiltInOpenAiConfig(config: String): String {
+        if (config.isBlank()) return ""
+        val lines = config.lines()
+        var inTopLevel = true
+        var activeProvider: String? = null
+        val providerPattern = Regex("""^\s*model_provider\s*=\s*[\"']([^\"']+)[\"']\s*(?:#.*)?$""")
+        lines.forEach { line ->
+            if (line.trimStart().startsWith("[")) inTopLevel = false
+            if (inTopLevel && activeProvider == null) {
+                activeProvider = providerPattern.matchEntire(line)?.groupValues?.getOrNull(1)
+            }
+        }
+        val customProvider = activeProvider?.takeUnless { it.equals("openai", ignoreCase = true) }
+        var skippingProviderSection = false
+        var beforeFirstSection = true
+        val output = mutableListOf<String>()
+        lines.forEach { line ->
+            val trimmed = line.trim()
+            val isSection = trimmed.startsWith("[") && trimmed.endsWith("]")
+            if (isSection) {
+                beforeFirstSection = false
+                skippingProviderSection = customProvider != null && isProviderSection(trimmed, customProvider)
+                if (!skippingProviderSection) output += line
+                return@forEach
+            }
+            if (skippingProviderSection) return@forEach
+            if (beforeFirstSection && customProvider != null) {
+                if (trimmed.matches(Regex("""model_provider\s*=.*"""))) return@forEach
+                if (trimmed.matches(Regex("""model\s*=.*"""))) return@forEach
+            }
+            output += line
+        }
+        return output.joinToString("\n").trimEnd() + "\n"
+    }
+
+    private fun importIntoFiles(
+        authFile: File,
+        authBackupSource: File,
+        configFile: File?,
+        configBackupSource: File?,
+        payload: String,
+        now: Instant,
+    ): CodexAuthImportResult {
+        val credentials = parseCredentials(payload)
+            ?: return CodexAuthImportResult(false, parseError(payload))
+        val authExisted = authBackupSource.isFile
+        val configExisted = configBackupSource?.isFile == true
+        var authBackup: File? = null
+        var configBackup: File? = null
+        return try {
+            val codexDir = authFile.parentFile ?: error("Codex auth directory is unavailable")
+            check(codexDir.exists() || codexDir.mkdirs())
+            val backupDir = File(codexDir, "import-backups").apply {
+                check(isDirectory || mkdirs())
+            }
+            val suffix = timestampSuffix(now)
+            authBackup = File(backupDir, "auth.$suffix.json.bak")
+                .takeIf { backupIfPresent(authBackupSource, it) }
+            configBackup = configBackupSource?.let { source ->
+                File(backupDir, "config.$suffix.toml.bak").takeIf { backupIfPresent(source, it) }
+            }
+
+            atomicWrite(authFile, buildOfficialAuth(credentials, now).toString(2) + "\n")
+            if (configFile?.isFile == true) {
+                val currentConfig = configFile.readText()
+                val activatedConfig = activateBuiltInOpenAiConfig(currentConfig)
+                if (activatedConfig != currentConfig) atomicWrite(configFile, activatedConfig)
+            }
+            CodexAuthImportResult(
+                success = true,
+                authBackupCreated = authBackup != null,
+                configBackupCreated = configBackup != null,
+                accountLabel = credentials.email
+                    ?: credentials.accountId?.let(::compactAccountLabel),
+            )
+        } catch (_: Exception) {
+            restoreAfterFailedImport(authFile, authBackup, authExisted)
+            if (configFile != null) restoreAfterFailedImport(configFile, configBackup, configExisted)
+            CodexAuthImportResult(false, CodexAuthImportError.WRITE_FAILED)
+        }
+    }
+
+    private fun parseRoots(payload: String): List<JSONObject>? {
+        val value = runCatching { JSONObject(payload) }.getOrNull()
+        if (value != null) return listOf(value)
+        val array = runCatching { JSONArray(payload) }.getOrNull() ?: return null
+        return buildList {
+            for (index in 0 until array.length()) array.optJSONObject(index)?.let(::add)
+        }.takeIf { it.isNotEmpty() }
+    }
+
+    private fun candidateObjects(roots: List<JSONObject>): List<JSONObject> {
+        val output = ArrayList<JSONObject>()
+        val seen = java.util.Collections.newSetFromMap(java.util.IdentityHashMap<JSONObject, Boolean>())
+        fun visit(value: Any?, depth: Int) {
+            if (value == null || depth > 8 || output.size >= MAX_JSON_NODES) return
+            when (value) {
+                is JSONObject -> {
+                    if (!seen.add(value)) return
+                    output += value
+                    val keys = value.keys()
+                    while (keys.hasNext()) {
+                        val key = keys.next()
+                        val child = value.opt(key)
+                        when (child) {
+                            is JSONObject, is JSONArray -> visit(child, depth + 1)
+                            is String -> if (key in SESSION_KEYS) {
+                                runCatching { JSONObject(child) }.getOrNull()?.let { visit(it, depth + 1) }
+                            }
+                        }
+                    }
+                }
+                is JSONArray -> for (index in 0 until value.length()) visit(value.opt(index), depth + 1)
+            }
+        }
+        roots.forEach { visit(it, 0) }
+        return output
+    }
+
+    private fun decodeJwtClaims(token: String): JSONObject? {
+        val parts = token.split(".")
+        if (parts.size != 3 || parts.any(String::isBlank)) return null
+        return runCatching {
+            val decoded = Base64.getUrlDecoder().decode(parts[1])
+            JSONObject(String(decoded, StandardCharsets.UTF_8))
+        }.getOrNull()
+    }
+
+    private fun accountIdFromClaims(claims: JSONObject): String? =
+        claims.firstString("https://api.openai.com/auth.chatgpt_account_id", "chatgpt_account_id")
+            ?: claims.optJSONObject("https://api.openai.com/auth")
+                ?.firstString("chatgpt_account_id", "account_id")
+
+    private fun JSONObject.firstString(vararg keys: String): String? {
+        keys.forEach { key ->
+            optString(key).trim().takeIf(String::isNotBlank)?.let { return it }
+        }
+        return null
+    }
+
+    private fun readLimited(context: Context, uri: Uri): ByteArray {
+        val output = ByteArrayOutputStream()
+        context.contentResolver.openInputStream(uri)?.use { input ->
+            val buffer = ByteArray(16 * 1024)
+            var total = 0
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                total += read
+                if (total > MAX_PAYLOAD_BYTES) return ByteArray(MAX_PAYLOAD_BYTES + 1)
+                output.write(buffer, 0, read)
+            }
+        } ?: error("Unable to read selected file")
+        return output.toByteArray()
+    }
+
+    private fun backupIfPresent(source: File, destination: File): Boolean {
+        if (!source.isFile) return false
+        source.copyTo(destination, overwrite = false)
+        securePermissions(destination)
+        return true
+    }
+
+    private fun restoreAfterFailedImport(target: File, backup: File?, existedBefore: Boolean) {
+        runCatching {
+            if (existedBefore && backup?.isFile == true) secureCopy(backup, target)
+            else if (!existedBefore && target.exists()) target.delete()
+        }
+    }
+
+    private fun atomicWrite(target: File, content: String) {
+        target.parentFile?.mkdirs()
+        val temporary = File(target.parentFile, ".${target.name}.${System.nanoTime()}.tmp")
+        temporary.writeText(content)
+        try {
+            Files.move(
+                temporary.toPath(),
+                target.toPath(),
+                StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING,
+            )
+        } catch (_: Exception) {
+            Files.move(temporary.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        } finally {
+            temporary.delete()
+        }
+        securePermissions(target)
+    }
+
+    private fun secureCopy(source: File, destination: File) {
+        destination.parentFile?.mkdirs()
+        Files.copy(source.toPath(), destination.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        securePermissions(destination)
+    }
+
+    private fun securePermissions(file: File) {
+        file.setReadable(false, false)
+        file.setWritable(false, false)
+        file.setExecutable(false, false)
+        file.setReadable(true, true)
+        file.setWritable(true, true)
+    }
+
+    private fun isProviderSection(section: String, provider: String): Boolean {
+        val normalized = section.removePrefix("[").removeSuffix("]").trim()
+        val quoted = "model_providers.\"$provider\""
+        val plain = "model_providers.$provider"
+        return normalized == quoted || normalized.startsWith("$quoted.") ||
+            normalized == plain || normalized.startsWith("$plain.")
+    }
+
+    private fun isIsoInstant(value: String): Boolean = try {
+        Instant.parse(value)
+        true
+    } catch (_: DateTimeParseException) {
+        false
+    }
+
+    private fun compactAccountLabel(accountId: String): String =
+        if (accountId.length <= 12) accountId else "${accountId.take(6)}…${accountId.takeLast(4)}"
+
+    private fun timestampSuffix(now: Instant): String = now.toString()
+        .replace(":", "")
+        .replace("-", "")
+        .replace(".", "")
+
+    internal data class ImportedCodexCredentials(
+        val idToken: String,
+        val accessToken: String,
+        val refreshToken: String,
+        val accountId: String?,
+        val lastRefresh: String?,
+        val email: String?,
+    )
+
+    private val SESSION_KEYS = setOf("session", "session_json", "sessionJson")
+}

--- a/app/src/main/java/com/kite/app/agent/auth/CodexAuthJsonImporter.kt
+++ b/app/src/main/java/com/kite/app/agent/auth/CodexAuthJsonImporter.kt
@@ -4,16 +4,13 @@ import android.content.Context
 import android.net.Uri
 import com.kite.app.agent.config.ContainerAgentConfigProjection
 import com.kite.app.foundation.workspace.WorkSurfaceRuntimeBridge
-import org.json.JSONArray
 import org.json.JSONObject
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.FileOutputStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
-import java.time.Instant
-import java.time.format.DateTimeParseException
-import java.util.Base64
 
 internal enum class CodexAuthImportError {
     INVALID_JSON,
@@ -30,18 +27,18 @@ internal data class CodexAuthImportResult(
     val error: CodexAuthImportError? = null,
     val authBackupCreated: Boolean = false,
     val configBackupCreated: Boolean = false,
-    val accountLabel: String? = null,
 )
 
 /**
- * 把官方 auth.json、CPA 单账号导出和 Sub2API accounts 导出统一成 Codex 原生凭据。
+ * Imports the native Codex `auth.json` format into the active PRoot View.
  *
- * 认证文件只会写入当前容器的可见/可写 PRoot View，避免直接改 Base rootfs 后活跃 View
- * 仍然读取旧内容。导入前会备份现有文件，正文不会写入日志、异常消息或结果对象。
+ * This first, deliberately narrow PR treats the selected file as opaque
+ * credential data: it only validates the outer native shape and writes the
+ * original bytes unchanged. Rollback snapshots are same-directory temporary
+ * files and are deleted after a successful import or a failed rollback.
  */
 internal object CodexAuthJsonImporter {
     private const val MAX_PAYLOAD_BYTES = 1024 * 1024
-    private const val MAX_JSON_NODES = 512
     private const val AUTH_PATH = "/root/.codex/auth.json"
     private const val CONFIG_PATH = "/root/.codex/config.toml"
 
@@ -54,7 +51,6 @@ internal object CodexAuthJsonImporter {
     fun importIntoDefaultContainer(
         context: Context,
         payload: ByteArray,
-        now: Instant = Instant.now(),
     ): CodexAuthImportResult {
         if (payload.isEmpty() || payload.size > MAX_PAYLOAD_BYTES) {
             return CodexAuthImportResult(false, CodexAuthImportError.INVALID_JSON)
@@ -72,8 +68,7 @@ internal object CodexAuthJsonImporter {
                 authBackupSource = authProjection.readFile,
                 configFile = configProjection?.writeFile,
                 configBackupSource = configProjection?.readFile,
-                payload = payload.toString(StandardCharsets.UTF_8),
-                now = now,
+                payload = payload,
             )
         }.getOrElse { CodexAuthImportResult(false, CodexAuthImportError.WRITE_FAILED) }
     }
@@ -81,7 +76,6 @@ internal object CodexAuthJsonImporter {
     internal fun importIntoRootfs(
         rootfsDir: File,
         payload: String,
-        now: Instant = Instant.now(),
     ): CodexAuthImportResult {
         val codexDir = File(rootfsDir, "root/.codex")
         return importIntoFiles(
@@ -89,84 +83,73 @@ internal object CodexAuthJsonImporter {
             authBackupSource = File(codexDir, "auth.json"),
             configFile = File(codexDir, "config.toml"),
             configBackupSource = File(codexDir, "config.toml"),
-            payload = payload,
-            now = now,
+            payload = payload.toByteArray(StandardCharsets.UTF_8),
         )
     }
 
-    internal fun parseCredentials(payload: String): ImportedCodexCredentials? {
-        val roots = parseRoots(payload) ?: return null
-        val objects = candidateObjects(roots)
-        for (candidate in objects) {
-            val tokenObject = candidate.optJSONObject("tokens") ?: candidate
-            val idToken = tokenObject.firstString("id_token", "idToken") ?: continue
-            val accessToken = tokenObject.firstString("access_token", "accessToken") ?: continue
-            val refreshToken = tokenObject.firstString("refresh_token", "refreshToken") ?: continue
-            val idClaims = decodeJwtClaims(idToken) ?: return null
-            val accountId = tokenObject.firstString(
-                "account_id",
-                "accountId",
-                "chatgpt_account_id",
-                "chatgptAccountId",
-            ) ?: candidate.firstString(
-                "account_id",
-                "accountId",
-                "chatgpt_account_id",
-                "chatgptAccountId",
-            ) ?: accountIdFromClaims(idClaims)
-            val lastRefresh = candidate.firstString("last_refresh", "lastRefresh")
-                ?.takeIf(::isIsoInstant)
-                ?: roots.firstNotNullOfOrNull { it.firstString("last_refresh", "lastRefresh")?.takeIf(::isIsoInstant) }
-            val email = candidate.firstString("email")
-                ?: roots.firstNotNullOfOrNull { it.firstString("email") }
-                ?: idClaims.firstString("email")
-            return ImportedCodexCredentials(
-                idToken = idToken,
-                accessToken = accessToken,
-                refreshToken = refreshToken,
-                accountId = accountId,
-                lastRefresh = lastRefresh,
-                email = email,
-            )
+    internal fun validateOfficialAuthJson(payload: String): CodexAuthImportError? {
+        val root = runCatching { JSONObject(payload) }.getOrNull()
+            ?: return CodexAuthImportError.INVALID_JSON
+        if (!root.optString("auth_mode").equals("chatgpt", ignoreCase = true)) {
+            return CodexAuthImportError.INVALID_JSON
+        }
+        val tokens = root.optJSONObject("tokens")
+            ?: return CodexAuthImportError.MISSING_ID_TOKEN
+        if (tokens.optString("id_token").isBlank()) {
+            return CodexAuthImportError.MISSING_ID_TOKEN
+        }
+        if (tokens.optString("access_token").isBlank()) {
+            return CodexAuthImportError.MISSING_ACCESS_TOKEN
+        }
+        if (tokens.optString("refresh_token").isBlank()) {
+            return CodexAuthImportError.MISSING_REFRESH_TOKEN
         }
         return null
     }
 
-    internal fun parseError(payload: String): CodexAuthImportError {
-        val roots = parseRoots(payload) ?: return CodexAuthImportError.INVALID_JSON
-        val objects = candidateObjects(roots)
-        val tokenObject = objects.firstOrNull { candidate ->
-            val tokens = candidate.optJSONObject("tokens") ?: candidate
-            tokens.firstString("id_token", "idToken") != null
-        }?.let { it.optJSONObject("tokens") ?: it }
-            ?: return CodexAuthImportError.MISSING_ID_TOKEN
-        if (tokenObject.firstString("access_token", "accessToken") == null) {
-            return CodexAuthImportError.MISSING_ACCESS_TOKEN
-        }
-        if (tokenObject.firstString("refresh_token", "refreshToken") == null) {
-            return CodexAuthImportError.MISSING_REFRESH_TOKEN
-        }
-        return if (decodeJwtClaims(tokenObject.firstString("id_token", "idToken").orEmpty()) == null) {
-            CodexAuthImportError.INVALID_ID_TOKEN
-        } else {
-            CodexAuthImportError.INVALID_JSON
+    private fun importIntoFiles(
+        authFile: File,
+        authBackupSource: File,
+        configFile: File?,
+        configBackupSource: File?,
+        payload: ByteArray,
+    ): CodexAuthImportResult {
+        val validationError = validateOfficialAuthJson(payload.toString(StandardCharsets.UTF_8))
+        if (validationError != null) return CodexAuthImportResult(false, validationError)
+
+        var authRollback: RollbackSnapshot? = null
+        var configRollback: RollbackSnapshot? = null
+        return try {
+            val codexDir = authFile.parentFile ?: error("Codex auth directory is unavailable")
+            check(codexDir.exists() || codexDir.mkdirs())
+            authRollback = createRollbackSnapshot(authBackupSource, codexDir)
+            configRollback = configBackupSource?.let { createRollbackSnapshot(it, codexDir) }
+
+            writeAtomic(authFile, payload)
+            if (configFile?.isFile == true) {
+                val currentConfig = configFile.readText()
+                val activatedConfig = activateBuiltInOpenAiConfig(currentConfig)
+                if (activatedConfig != currentConfig) {
+                    writeAtomic(configFile, activatedConfig.toByteArray(StandardCharsets.UTF_8))
+                }
+            }
+
+            val result = CodexAuthImportResult(
+                success = true,
+                authBackupCreated = authRollback?.file != null,
+                configBackupCreated = configRollback?.file != null,
+            )
+            authRollback?.delete()
+            configRollback?.delete()
+            result
+        } catch (_: Exception) {
+            restoreAfterFailedImport(authFile, authRollback)
+            if (configFile != null) restoreAfterFailedImport(configFile, configRollback)
+            authRollback?.delete()
+            configRollback?.delete()
+            CodexAuthImportResult(false, CodexAuthImportError.WRITE_FAILED)
         }
     }
-
-    internal fun buildOfficialAuth(
-        credentials: ImportedCodexCredentials,
-        now: Instant,
-    ): JSONObject = JSONObject()
-        .put("auth_mode", "chatgpt")
-        .put(
-            "tokens",
-            JSONObject()
-                .put("id_token", credentials.idToken)
-                .put("access_token", credentials.accessToken)
-                .put("refresh_token", credentials.refreshToken)
-                .apply { credentials.accountId?.let { put("account_id", it) } },
-        )
-        .put("last_refresh", credentials.lastRefresh ?: now.toString())
 
     internal fun activateBuiltInOpenAiConfig(config: String): String {
         if (config.isBlank()) return ""
@@ -203,158 +186,50 @@ internal object CodexAuthJsonImporter {
         return output.joinToString("\n").trimEnd() + "\n"
     }
 
-    private fun importIntoFiles(
-        authFile: File,
-        authBackupSource: File,
-        configFile: File?,
-        configBackupSource: File?,
-        payload: String,
-        now: Instant,
-    ): CodexAuthImportResult {
-        val credentials = parseCredentials(payload)
-            ?: return CodexAuthImportResult(false, parseError(payload))
-        val authExisted = authBackupSource.isFile
-        val configExisted = configBackupSource?.isFile == true
-        var authBackup: File? = null
-        var configBackup: File? = null
-        return try {
-            val codexDir = authFile.parentFile ?: error("Codex auth directory is unavailable")
-            check(codexDir.exists() || codexDir.mkdirs())
-            val backupDir = File(codexDir, "import-backups").apply {
-                check(isDirectory || mkdirs())
-            }
-            val suffix = timestampSuffix(now)
-            authBackup = File(backupDir, "auth.$suffix.json.bak")
-                .takeIf { backupIfPresent(authBackupSource, it) }
-            configBackup = configBackupSource?.let { source ->
-                File(backupDir, "config.$suffix.toml.bak").takeIf { backupIfPresent(source, it) }
-            }
+    private fun parseRollbackPath(directory: File): File =
+        File(directory, ".kite-auth-rollback-${System.nanoTime()}.tmp")
 
-            atomicWrite(authFile, buildOfficialAuth(credentials, now).toString(2) + "\n")
-            if (configFile?.isFile == true) {
-                val currentConfig = configFile.readText()
-                val activatedConfig = activateBuiltInOpenAiConfig(currentConfig)
-                if (activatedConfig != currentConfig) atomicWrite(configFile, activatedConfig)
-            }
-            CodexAuthImportResult(
-                success = true,
-                authBackupCreated = authBackup != null,
-                configBackupCreated = configBackup != null,
-                accountLabel = credentials.email
-                    ?: credentials.accountId?.let(::compactAccountLabel),
-            )
-        } catch (_: Exception) {
-            restoreAfterFailedImport(authFile, authBackup, authExisted)
-            if (configFile != null) restoreAfterFailedImport(configFile, configBackup, configExisted)
-            CodexAuthImportResult(false, CodexAuthImportError.WRITE_FAILED)
-        }
+    private fun createRollbackSnapshot(source: File, directory: File): RollbackSnapshot {
+        if (!source.isFile) return RollbackSnapshot(null, existedBefore = false)
+        val snapshot = parseRollbackPath(directory)
+        secureCopy(source, snapshot)
+        return RollbackSnapshot(snapshot, existedBefore = true)
     }
 
-    private fun parseRoots(payload: String): List<JSONObject>? {
-        val value = runCatching { JSONObject(payload) }.getOrNull()
-        if (value != null) return listOf(value)
-        val array = runCatching { JSONArray(payload) }.getOrNull() ?: return null
-        return buildList {
-            for (index in 0 until array.length()) array.optJSONObject(index)?.let(::add)
-        }.takeIf { it.isNotEmpty() }
-    }
-
-    private fun candidateObjects(roots: List<JSONObject>): List<JSONObject> {
-        val output = ArrayList<JSONObject>()
-        val seen = java.util.Collections.newSetFromMap(java.util.IdentityHashMap<JSONObject, Boolean>())
-        fun visit(value: Any?, depth: Int) {
-            if (value == null || depth > 8 || output.size >= MAX_JSON_NODES) return
-            when (value) {
-                is JSONObject -> {
-                    if (!seen.add(value)) return
-                    output += value
-                    val keys = value.keys()
-                    while (keys.hasNext()) {
-                        val key = keys.next()
-                        val child = value.opt(key)
-                        when (child) {
-                            is JSONObject, is JSONArray -> visit(child, depth + 1)
-                            is String -> if (key in SESSION_KEYS) {
-                                runCatching { JSONObject(child) }.getOrNull()?.let { visit(it, depth + 1) }
-                            }
-                        }
-                    }
-                }
-                is JSONArray -> for (index in 0 until value.length()) visit(value.opt(index), depth + 1)
-            }
-        }
-        roots.forEach { visit(it, 0) }
-        return output
-    }
-
-    private fun decodeJwtClaims(token: String): JSONObject? {
-        val parts = token.split(".")
-        if (parts.size != 3 || parts.any(String::isBlank)) return null
-        return runCatching {
-            val decoded = Base64.getUrlDecoder().decode(parts[1])
-            JSONObject(String(decoded, StandardCharsets.UTF_8))
-        }.getOrNull()
-    }
-
-    private fun accountIdFromClaims(claims: JSONObject): String? =
-        claims.firstString("https://api.openai.com/auth.chatgpt_account_id", "chatgpt_account_id")
-            ?: claims.optJSONObject("https://api.openai.com/auth")
-                ?.firstString("chatgpt_account_id", "account_id")
-
-    private fun JSONObject.firstString(vararg keys: String): String? {
-        keys.forEach { key ->
-            optString(key).trim().takeIf(String::isNotBlank)?.let { return it }
-        }
-        return null
-    }
-
-    private fun readLimited(context: Context, uri: Uri): ByteArray {
-        val output = ByteArrayOutputStream()
-        context.contentResolver.openInputStream(uri)?.use { input ->
-            val buffer = ByteArray(16 * 1024)
-            var total = 0
-            while (true) {
-                val read = input.read(buffer)
-                if (read < 0) break
-                total += read
-                if (total > MAX_PAYLOAD_BYTES) return ByteArray(MAX_PAYLOAD_BYTES + 1)
-                output.write(buffer, 0, read)
-            }
-        } ?: error("Unable to read selected file")
-        return output.toByteArray()
-    }
-
-    private fun backupIfPresent(source: File, destination: File): Boolean {
-        if (!source.isFile) return false
-        source.copyTo(destination, overwrite = false)
-        securePermissions(destination)
-        return true
-    }
-
-    private fun restoreAfterFailedImport(target: File, backup: File?, existedBefore: Boolean) {
+    private fun restoreAfterFailedImport(target: File, snapshot: RollbackSnapshot?) {
         runCatching {
-            if (existedBefore && backup?.isFile == true) secureCopy(backup, target)
-            else if (!existedBefore && target.exists()) target.delete()
+            if (snapshot?.existedBefore == true && snapshot.file?.isFile == true) {
+                secureCopy(snapshot.file, target)
+            } else if (snapshot != null && target.exists()) {
+                target.delete()
+            }
         }
     }
 
-    private fun atomicWrite(target: File, content: String) {
+    private fun writeAtomic(target: File, content: ByteArray) {
         target.parentFile?.mkdirs()
         val temporary = File(target.parentFile, ".${target.name}.${System.nanoTime()}.tmp")
-        temporary.writeText(content)
         try {
-            Files.move(
-                temporary.toPath(),
-                target.toPath(),
-                StandardCopyOption.ATOMIC_MOVE,
-                StandardCopyOption.REPLACE_EXISTING,
-            )
-        } catch (_: Exception) {
-            Files.move(temporary.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+            FileOutputStream(temporary).use { stream ->
+                stream.write(content)
+                stream.flush()
+                stream.fd.sync()
+            }
+            securePermissions(temporary)
+            try {
+                Files.move(
+                    temporary.toPath(),
+                    target.toPath(),
+                    StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING,
+                )
+            } catch (_: Exception) {
+                Files.move(temporary.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+            }
+            securePermissions(target)
         } finally {
             temporary.delete()
         }
-        securePermissions(target)
     }
 
     private fun secureCopy(source: File, destination: File) {
@@ -379,29 +254,28 @@ internal object CodexAuthJsonImporter {
             normalized == plain || normalized.startsWith("$plain.")
     }
 
-    private fun isIsoInstant(value: String): Boolean = try {
-        Instant.parse(value)
-        true
-    } catch (_: DateTimeParseException) {
-        false
+    private fun readLimited(context: Context, uri: Uri): ByteArray {
+        val output = ByteArrayOutputStream()
+        context.contentResolver.openInputStream(uri)?.use { input ->
+            val buffer = ByteArray(16 * 1024)
+            var total = 0
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                total += read
+                if (total > MAX_PAYLOAD_BYTES) return ByteArray(MAX_PAYLOAD_BYTES + 1)
+                output.write(buffer, 0, read)
+            }
+        } ?: error("Unable to read selected file")
+        return output.toByteArray()
     }
 
-    private fun compactAccountLabel(accountId: String): String =
-        if (accountId.length <= 12) accountId else "${accountId.take(6)}…${accountId.takeLast(4)}"
-
-    private fun timestampSuffix(now: Instant): String = now.toString()
-        .replace(":", "")
-        .replace("-", "")
-        .replace(".", "")
-
-    internal data class ImportedCodexCredentials(
-        val idToken: String,
-        val accessToken: String,
-        val refreshToken: String,
-        val accountId: String?,
-        val lastRefresh: String?,
-        val email: String?,
-    )
-
-    private val SESSION_KEYS = setOf("session", "session_json", "sessionJson")
+    private data class RollbackSnapshot(
+        val file: File?,
+        val existedBefore: Boolean,
+    ) {
+        fun delete() {
+            file?.delete()
+        }
+    }
 }

--- a/app/src/main/java/com/kite/app/feature/runsurface/RunAgentSurfaceBinding.kt
+++ b/app/src/main/java/com/kite/app/feature/runsurface/RunAgentSurfaceBinding.kt
@@ -164,6 +164,7 @@ internal class RunAgentSurfaceBinding(
     private val onCloseInstance: () -> Unit,
     private val onPickImages: () -> Unit,
     private val onPickFiles: () -> Unit,
+    private val onPickCodexAuthJson: () -> Unit,
     private val agentRegistry: KiteAgentRegistry,
     private val officialAccountManager: AgentOfficialAccountManager,
     private val agentConfigurationApi: AgentConfigurationApi,
@@ -5637,6 +5638,12 @@ internal class RunAgentSurfaceBinding(
                     setTextColor(tokens.textSecondary)
                     setPadding(0, ui.dp(5), 0, ui.dp(13))
                 })
+                if (providerLibraryMode == AgentProviderLibraryMode.Browse && targetAgentId == "codex") {
+                    addView(buildCodexAuthImportCard(), LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ).apply { bottomMargin = ui.dp(12) })
+                }
                 if (providerLibraryMode == AgentProviderLibraryMode.Browse) {
                     addView(buildProviderGroupStrip(
                         selected,
@@ -6339,6 +6346,49 @@ internal class RunAgentSurfaceBinding(
                 else -> officialAccountManager.login(agentId, account.id)
             }
         }
+    }
+
+    private fun buildCodexAuthImportCard(): View = LinearLayout(context).apply {
+        orientation = LinearLayout.HORIZONTAL
+        gravity = Gravity.CENTER_VERTICAL
+        setPadding(ui.dp(16), ui.dp(12), ui.dp(10), ui.dp(12))
+        background = ui.roundedBox(
+            agentSettingsSurface,
+            tokens.border,
+            ui.dp(18).toFloat(),
+            ui.dp(1),
+        )
+        addView(LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+            addView(TextView(context).apply {
+                text = context.getString(R.string.agent_codex_auth_import_title)
+                textSize = 15f
+                typeface = Typeface.DEFAULT_BOLD
+                setTextColor(tokens.textPrimary)
+            })
+            addView(TextView(context).apply {
+                text = context.getString(R.string.agent_codex_auth_import_summary)
+                textSize = 12.5f
+                setTextColor(tokens.textSecondary)
+                setPadding(0, ui.dp(4), ui.dp(10), 0)
+            })
+        }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+        addView(TextView(context).apply {
+            text = context.getString(R.string.agent_codex_auth_import_action)
+            textSize = 13.5f
+            typeface = Typeface.DEFAULT_BOLD
+            gravity = Gravity.CENTER
+            setTextColor(tokens.textPrimary)
+            setPadding(ui.dp(12), 0, ui.dp(12), 0)
+            background = ui.roundedBox(agentSurface, tokens.border, ui.dp(16).toFloat(), ui.dp(1))
+            isClickable = true
+            isFocusable = true
+            setOnClickListener { onPickCodexAuthJson() }
+        }, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ui.dp(40)))
+    }
+
+    fun refreshCodexOfficialAccountStatus() {
+        officialAccountManager.refresh("codex", "chatgpt")
     }
 
     private fun AgentOfficialAccountStatus.officialAccountLabel(): String = when (this) {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -9,6 +9,10 @@
     <string name="common_retry">Retry</string>
     <string name="common_more">More</string>
     <string name="common_cancel">Cancel</string>
+    <string name="agent_codex_auth_import_title">Import Codex JSON auth</string>
+    <string name="agent_codex_auth_import_summary">Supports official auth.json, CPA single-account, and Sub2API accounts exports; processed locally only.</string>
+    <string name="agent_codex_auth_import_action">Choose JSON</string>
+    <string name="agent_codex_auth_import_success">Codex authentication imported and activated; existing auth and config were backed up.</string>
 
     <string name="settings_title">Settings</string>
     <string name="settings_section_personalization">Personalization</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -10,9 +10,9 @@
     <string name="common_more">More</string>
     <string name="common_cancel">Cancel</string>
     <string name="agent_codex_auth_import_title">Import Codex JSON auth</string>
-    <string name="agent_codex_auth_import_summary">Supports official auth.json, CPA single-account, and Sub2API accounts exports; processed locally only.</string>
+    <string name="agent_codex_auth_import_summary">Imports the official auth.json used by the active container; processed locally only.</string>
     <string name="agent_codex_auth_import_action">Choose JSON</string>
-    <string name="agent_codex_auth_import_success">Codex authentication imported and activated; existing auth and config were backed up.</string>
+    <string name="agent_codex_auth_import_success">Codex authentication imported and activated; temporary rollback snapshots are used only on failure.</string>
 
     <string name="settings_title">Settings</string>
     <string name="settings_section_personalization">Personalization</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,9 +9,9 @@
     <string name="common_more">更多</string>
     <string name="common_cancel">取消</string>
     <string name="agent_codex_auth_import_title">导入 Codex JSON 认证</string>
-    <string name="agent_codex_auth_import_summary">支持官方 auth.json、CPA 单账号和 Sub2API accounts 导出；文件只在本机处理。</string>
+    <string name="agent_codex_auth_import_summary">导入当前容器使用的官方 auth.json；文件只在本机处理。</string>
     <string name="agent_codex_auth_import_action">选择 JSON</string>
-    <string name="agent_codex_auth_import_success">Codex 认证已导入并激活；现有认证和配置已备份。</string>
+    <string name="agent_codex_auth_import_success">Codex 认证已导入并激活；失败时才会用临时快照回滚。</string>
 
     <string name="settings_title">设置</string>
     <string name="settings_section_personalization">个性化</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,10 @@
     <string name="common_retry">重试</string>
     <string name="common_more">更多</string>
     <string name="common_cancel">取消</string>
+    <string name="agent_codex_auth_import_title">导入 Codex JSON 认证</string>
+    <string name="agent_codex_auth_import_summary">支持官方 auth.json、CPA 单账号和 Sub2API accounts 导出；文件只在本机处理。</string>
+    <string name="agent_codex_auth_import_action">选择 JSON</string>
+    <string name="agent_codex_auth_import_success">Codex 认证已导入并激活；现有认证和配置已备份。</string>
 
     <string name="settings_title">设置</string>
     <string name="settings_section_personalization">个性化</string>

--- a/app/src/test/kotlin/com/kite/app/agent/auth/CodexAuthJsonImporterTest.kt
+++ b/app/src/test/kotlin/com/kite/app/agent/auth/CodexAuthJsonImporterTest.kt
@@ -1,0 +1,154 @@
+package com.kite.app.agent.auth
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+import java.time.Instant
+import java.util.Base64
+
+@RunWith(RobolectricTestRunner::class)
+class CodexAuthJsonImporterTest {
+    @get:Rule
+    val temp = TemporaryFolder()
+
+    @Test
+    fun `official and CPA credentials activate built in Codex provider`() {
+        val rootfs = temp.newFolder("rootfs")
+        val codexDir = File(rootfs, "root/.codex").apply { mkdirs() }
+        File(codexDir, "auth.json").writeText("""{"OPENAI_API_KEY":"old-key"}""")
+        File(codexDir, "config.toml").writeText(
+            """
+            model_provider = "custom"
+            model = "third-party-model"
+            model_reasoning_effort = "high"
+
+            [model_providers.custom]
+            name = "custom"
+            base_url = "https://example.test/v1"
+
+            [projects."/workspace"]
+            trust_level = "trusted"
+            """.trimIndent() + "\n",
+        )
+        val idToken = jwt("""{"sub":"official-user","email":"official@example.test"}""")
+        val payload = JSONObject()
+            .put("id_token", idToken)
+            .put("access_token", "access")
+            .put("refresh_token", "refresh")
+            .put("account_id", "official-account")
+            .put("last_refresh", "2026-07-26T12:00:00Z")
+            .toString()
+
+        val result = CodexAuthJsonImporter.importIntoRootfs(
+            rootfs,
+            payload,
+            Instant.parse("2026-07-26T13:00:00Z"),
+        )
+
+        assertTrue(result.success)
+        assertTrue(result.authBackupCreated)
+        assertTrue(result.configBackupCreated)
+        val auth = JSONObject(File(codexDir, "auth.json").readText())
+        assertEquals("chatgpt", auth.getString("auth_mode"))
+        assertEquals("official-account", auth.getJSONObject("tokens").getString("account_id"))
+        val config = File(codexDir, "config.toml").readText()
+        assertFalse(config.contains("model_provider"))
+        assertFalse(config.contains("third-party-model"))
+        assertFalse(config.contains("[model_providers.custom]"))
+        assertTrue(config.contains("model_reasoning_effort = \"high\""))
+        assertTrue(config.contains("[projects.\"/workspace\"]"))
+    }
+
+    @Test
+    fun `Sub2API accounts export is normalized from nested credentials`() {
+        val rootfs = temp.newFolder("sub2api-rootfs")
+        val idToken = jwt("""{"sub":"sub2api-user","email":"sub2api@example.test"}""")
+        val payload = JSONObject()
+            .put("exported_at", "2026-08-05T00:00:00Z")
+            .put("proxies", JSONArray())
+            .put(
+                "accounts",
+                JSONArray().put(
+                    JSONObject()
+                        .put("name", "sub2api-account")
+                        .put("type", "codex")
+                        .put(
+                            "credentials",
+                            JSONObject()
+                                .put("access_token", "access")
+                                .put("expires_at", "2026-08-06T00:00:00Z")
+                                .put("refresh_token", "refresh")
+                                .put("id_token", idToken)
+                                .put("email", "sub2api@example.test")
+                                .put("chatgpt_account_id", "sub2api-account-id"),
+                        ),
+                ),
+            )
+            .put("type", "sub2api")
+            .put("version", 1)
+            .toString()
+
+        val result = CodexAuthJsonImporter.importIntoRootfs(rootfs, payload)
+
+        assertTrue(result.success)
+        assertEquals("sub2api@example.test", result.accountLabel)
+        assertEquals(
+            "sub2api-account-id",
+            JSONObject(File(rootfs, "root/.codex/auth.json").readText())
+                .getJSONObject("tokens")
+                .getString("account_id"),
+        )
+    }
+
+    @Test
+    fun `wrapped session and CPA array are accepted`() {
+        val idToken = jwt("""{"sub":"array-user"}""")
+        val nested = JSONObject()
+            .put("tokens", JSONObject()
+                .put("id_token", idToken)
+                .put("access_token", "access")
+                .put("refresh_token", "refresh")
+                .put("account_id", "array-account"))
+        val wrapped = JSONObject().put("session_json", nested.toString()).toString()
+        assertEquals("array-account", CodexAuthJsonImporter.parseCredentials(wrapped)?.accountId)
+
+        val array = JSONArray().put(
+            JSONObject()
+                .put("id_token", idToken)
+                .put("access_token", "access")
+                .put("refresh_token", "refresh")
+                .put("account_id", "array-account"),
+        ).toString()
+        assertEquals("array-account", CodexAuthJsonImporter.parseCredentials(array)?.accountId)
+    }
+
+    @Test
+    fun `missing refresh token is rejected without writing auth`() {
+        val rootfs = temp.newFolder("invalid-rootfs")
+        val payload = JSONObject()
+            .put("id_token", jwt("""{"sub":"user"}"""))
+            .put("access_token", "access")
+            .toString()
+
+        val result = CodexAuthJsonImporter.importIntoRootfs(rootfs, payload)
+
+        assertFalse(result.success)
+        assertEquals(CodexAuthImportError.MISSING_REFRESH_TOKEN, result.error)
+        assertFalse(File(rootfs, "root/.codex/auth.json").exists())
+    }
+
+    private fun jwt(payload: String): String {
+        val encoder = Base64.getUrlEncoder().withoutPadding()
+        val header = encoder.encodeToString("""{"alg":"none","typ":"JWT"}""".toByteArray())
+        val body = encoder.encodeToString(payload.toByteArray())
+        return "$header.$body.signature"
+    }
+}

--- a/app/src/test/kotlin/com/kite/app/agent/auth/CodexAuthJsonImporterTest.kt
+++ b/app/src/test/kotlin/com/kite/app/agent/auth/CodexAuthJsonImporterTest.kt
@@ -1,6 +1,5 @@
 package com.kite.app.agent.auth
 
-import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -11,8 +10,6 @@ import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.io.File
-import java.time.Instant
-import java.util.Base64
 
 @RunWith(RobolectricTestRunner::class)
 class CodexAuthJsonImporterTest {
@@ -20,7 +17,7 @@ class CodexAuthJsonImporterTest {
     val temp = TemporaryFolder()
 
     @Test
-    fun `official and CPA credentials activate built in Codex provider`() {
+    fun `official auth json is written byte for byte and activates built in provider`() {
         val rootfs = temp.newFolder("rootfs")
         val codexDir = File(rootfs, "root/.codex").apply { mkdirs() }
         File(codexDir, "auth.json").writeText("""{"OPENAI_API_KEY":"old-key"}""")
@@ -38,27 +35,26 @@ class CodexAuthJsonImporterTest {
             trust_level = "trusted"
             """.trimIndent() + "\n",
         )
-        val idToken = jwt("""{"sub":"official-user","email":"official@example.test"}""")
         val payload = JSONObject()
-            .put("id_token", idToken)
-            .put("access_token", "access")
-            .put("refresh_token", "refresh")
-            .put("account_id", "official-account")
+            .put("auth_mode", "chatgpt")
+            .put(
+                "tokens",
+                JSONObject()
+                    .put("id_token", "opaque-id-token")
+                    .put("access_token", "opaque-access-token")
+                    .put("refresh_token", "opaque-refresh-token")
+                    .put("account_id", "official-account"),
+            )
             .put("last_refresh", "2026-07-26T12:00:00Z")
-            .toString()
+            .toString(2) + "\n"
 
-        val result = CodexAuthJsonImporter.importIntoRootfs(
-            rootfs,
-            payload,
-            Instant.parse("2026-07-26T13:00:00Z"),
-        )
+        val result = CodexAuthJsonImporter.importIntoRootfs(rootfs, payload)
 
         assertTrue(result.success)
         assertTrue(result.authBackupCreated)
         assertTrue(result.configBackupCreated)
-        val auth = JSONObject(File(codexDir, "auth.json").readText())
-        assertEquals("chatgpt", auth.getString("auth_mode"))
-        assertEquals("official-account", auth.getJSONObject("tokens").getString("account_id"))
+        assertEquals(payload, File(codexDir, "auth.json").readText())
+        assertFalse(File(codexDir, "import-backups").exists())
         val config = File(codexDir, "config.toml").readText()
         assertFalse(config.contains("model_provider"))
         assertFalse(config.contains("third-party-model"))
@@ -68,74 +64,33 @@ class CodexAuthJsonImporterTest {
     }
 
     @Test
-    fun `Sub2API accounts export is normalized from nested credentials`() {
-        val rootfs = temp.newFolder("sub2api-rootfs")
-        val idToken = jwt("""{"sub":"sub2api-user","email":"sub2api@example.test"}""")
-        val payload = JSONObject()
-            .put("exported_at", "2026-08-05T00:00:00Z")
-            .put("proxies", JSONArray())
-            .put(
-                "accounts",
-                JSONArray().put(
-                    JSONObject()
-                        .put("name", "sub2api-account")
-                        .put("type", "codex")
-                        .put(
-                            "credentials",
-                            JSONObject()
-                                .put("access_token", "access")
-                                .put("expires_at", "2026-08-06T00:00:00Z")
-                                .put("refresh_token", "refresh")
-                                .put("id_token", idToken)
-                                .put("email", "sub2api@example.test")
-                                .put("chatgpt_account_id", "sub2api-account-id"),
-                        ),
-                ),
-            )
-            .put("type", "sub2api")
-            .put("version", 1)
-            .toString()
-
-        val result = CodexAuthJsonImporter.importIntoRootfs(rootfs, payload)
-
-        assertTrue(result.success)
-        assertEquals("sub2api@example.test", result.accountLabel)
-        assertEquals(
-            "sub2api-account-id",
-            JSONObject(File(rootfs, "root/.codex/auth.json").readText())
-                .getJSONObject("tokens")
-                .getString("account_id"),
-        )
-    }
-
-    @Test
-    fun `wrapped session and CPA array are accepted`() {
-        val idToken = jwt("""{"sub":"array-user"}""")
-        val nested = JSONObject()
-            .put("tokens", JSONObject()
-                .put("id_token", idToken)
-                .put("access_token", "access")
-                .put("refresh_token", "refresh")
-                .put("account_id", "array-account"))
-        val wrapped = JSONObject().put("session_json", nested.toString()).toString()
-        assertEquals("array-account", CodexAuthJsonImporter.parseCredentials(wrapped)?.accountId)
-
-        val array = JSONArray().put(
+    fun `flat export is rejected in the official-only PR`() {
+        val rootfs = temp.newFolder("flat-rootfs")
+        val result = CodexAuthJsonImporter.importIntoRootfs(
+            rootfs,
             JSONObject()
-                .put("id_token", idToken)
-                .put("access_token", "access")
-                .put("refresh_token", "refresh")
-                .put("account_id", "array-account"),
-        ).toString()
-        assertEquals("array-account", CodexAuthJsonImporter.parseCredentials(array)?.accountId)
+                .put("id_token", "opaque-id-token")
+                .put("access_token", "opaque-access-token")
+                .put("refresh_token", "opaque-refresh-token")
+                .toString(),
+        )
+
+        assertFalse(result.success)
+        assertEquals(CodexAuthImportError.INVALID_JSON, result.error)
+        assertFalse(File(rootfs, "root/.codex/auth.json").exists())
     }
 
     @Test
     fun `missing refresh token is rejected without writing auth`() {
         val rootfs = temp.newFolder("invalid-rootfs")
         val payload = JSONObject()
-            .put("id_token", jwt("""{"sub":"user"}"""))
-            .put("access_token", "access")
+            .put("auth_mode", "chatgpt")
+            .put(
+                "tokens",
+                JSONObject()
+                    .put("id_token", "opaque-id-token")
+                    .put("access_token", "opaque-access-token"),
+            )
             .toString()
 
         val result = CodexAuthJsonImporter.importIntoRootfs(rootfs, payload)
@@ -143,12 +98,5 @@ class CodexAuthJsonImporterTest {
         assertFalse(result.success)
         assertEquals(CodexAuthImportError.MISSING_REFRESH_TOKEN, result.error)
         assertFalse(File(rootfs, "root/.codex/auth.json").exists())
-    }
-
-    private fun jwt(payload: String): String {
-        val encoder = Base64.getUrlEncoder().withoutPadding()
-        val header = encoder.encodeToString("""{"alg":"none","typ":"JWT"}""".toByteArray())
-        val body = encoder.encodeToString(payload.toByteArray())
-        return "$header.$body.signature"
     }
 }


### PR DESCRIPTION
## Summary

- Add an Android file-picker action for importing the official native `auth.json` only.
- Treat credential contents as opaque: validate only the outer Codex shape, then write the selected bytes unchanged to the active container PRoot View at `/root/.codex/auth.json`.
- Activate the built-in OpenAI provider configuration without changing unrelated project settings.
- Use owner-only permissions, same-directory atomic replacement, and temporary rollback snapshots that are deleted after success or rollback.

## Scope

This PR deliberately excludes CPA, Sub2API, generic wrappers, multi-account storage/switching, proxies, and long-term credential backups. Those formats can be discussed separately after this official path is accepted.

## Consumption and rollback lifecycle

- Consumer: the existing Codex provider page imports the file; subsequent Codex CLI launches consume `/root/.codex/auth.json` directly.
- Restore timing: only during the same import operation if replacing auth/config fails.
- Deletion timing: rollback snapshots are deleted immediately after success or after rollback.
- No page reads these snapshots later, and they are not used for account switching or any other long-term scenario.

## Verification

- `./gradlew :app:compileDebugKotlin --no-daemon --offline --max-workers=1` — passed.
- Added Robolectric coverage for byte-for-byte official auth import, provider activation, temporary rollback lifecycle, and rejection of non-native/invalid inputs.
- Credential values are never logged, uploaded, committed, or included in test fixtures.

Closes #6.