### PR TITLE
feat(codex): support multi-account JSON imports

### DIFF
--- a/app/src/main/java/com/kite/app/CardRunActivity.kt
+++ b/app/src/main/java/com/kite/app/CardRunActivity.kt
@@ -22,6 +22,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.kite.app.action.KiteInstallPlanActionIntent
+import com.kite.app.agent.auth.CodexAuthImportError
+import com.kite.app.agent.auth.CodexAuthJsonImporter
 import com.kite.app.application.browser.BrowserHandoffCoordinator
 import com.kite.app.application.browser.BrowserHandoffLaunchResult
 import com.kite.app.application.resources.ResourceActionEffect
@@ -85,7 +87,9 @@ import com.kite.app.ui.theme.applyKiteWindowTheme
 import com.kite.app.ui.UiKit
 import com.kite.app.ui.terminal.KiteTerminalShellTheme
 import com.kite.app.shell.TerminalSurfaceShellBinding
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /** 只托管一个运行实例及其可见显示面，不拥有首页、资源目录或底层任务生命周期。 */
 class CardRunActivity : AppCompatActivity() {
@@ -120,6 +124,31 @@ class CardRunActivity : AppCompatActivity() {
         ActivityResultContracts.OpenMultipleDocuments()
     ) { uris ->
         agentSurfaceBinding?.addAttachments(uris)
+    }
+    private val codexAuthJsonPicker = registerForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        if (uri == null) return@registerForActivityResult
+        lifecycleScope.launch {
+            val result = withContext(Dispatchers.IO) {
+                CodexAuthJsonImporter.importFromUri(this@CardRunActivity, uri)
+            }
+            if (result.success) {
+                Toast.makeText(
+                    this@CardRunActivity,
+                    getString(com.kite.app.R.string.agent_codex_auth_import_success),
+                    Toast.LENGTH_LONG,
+                ).show()
+                graph.agentOfficialAccountManager.refresh("codex", "chatgpt")
+                agentSurfaceBinding?.refreshCodexOfficialAccountStatus()
+            } else {
+                Toast.makeText(
+                    this@CardRunActivity,
+                    codexAuthImportFailureMessage(result.error),
+                    Toast.LENGTH_LONG,
+                ).show()
+            }
+        }
     }
     private val backCallback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
@@ -414,6 +443,9 @@ class CardRunActivity : AppCompatActivity() {
                 agentAttachmentPicker.launch(
                     arrayOf("text/*", "application/pdf", "application/octet-stream")
                 )
+            },
+            onPickCodexAuthJson = {
+                codexAuthJsonPicker.launch(arrayOf("application/json", "text/plain", "application/octet-stream"))
             },
             agentRegistry = graph.agentRegistry,
             officialAccountManager = graph.agentOfficialAccountManager,
@@ -982,6 +1014,17 @@ class CardRunActivity : AppCompatActivity() {
     }
 
     private fun activeEnvironmentId(): String = graph.resourceInstallStore.currentEnvironmentId()
+
+    private fun codexAuthImportFailureMessage(error: CodexAuthImportError?): String = when (error) {
+        CodexAuthImportError.INVALID_JSON -> "导入失败：不是受支持的 JSON 认证文件，或文件超过 1 MB。"
+        CodexAuthImportError.MISSING_ID_TOKEN -> "导入失败：缺少 id_token。"
+        CodexAuthImportError.MISSING_ACCESS_TOKEN -> "导入失败：缺少 access_token。"
+        CodexAuthImportError.MISSING_REFRESH_TOKEN -> "导入失败：缺少 refresh_token。"
+        CodexAuthImportError.INVALID_ID_TOKEN -> "导入失败：id_token 不是有效的 JWT。"
+        CodexAuthImportError.CONTAINER_NOT_READY -> "导入失败：默认容器尚未准备完成。"
+        CodexAuthImportError.WRITE_FAILED,
+        null -> "导入失败：无法安全写入 Codex 认证文件。"
+    }
 
     private fun targetEnvironmentId(): String = boundEnvironmentId ?: activeEnvironmentId()
 

--- a/app/src/main/java/com/kite/app/CardRunActivity.kt
+++ b/app/src/main/java/com/kite/app/CardRunActivity.kt
@@ -16,6 +16,7 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.lifecycle.Lifecycle
@@ -136,7 +137,10 @@ class CardRunActivity : AppCompatActivity() {
             if (result.success) {
                 Toast.makeText(
                     this@CardRunActivity,
-                    getString(com.kite.app.R.string.agent_codex_auth_import_success),
+                    getString(
+                        com.kite.app.R.string.agent_codex_auth_import_success,
+                        result.importedAccountCount,
+                    ),
                     Toast.LENGTH_LONG,
                 ).show()
                 graph.agentOfficialAccountManager.refresh("codex", "chatgpt")
@@ -148,6 +152,59 @@ class CardRunActivity : AppCompatActivity() {
                     Toast.LENGTH_LONG,
                 ).show()
             }
+        }
+    }
+
+    private fun showCodexAccountSwitcher() {
+        lifecycleScope.launch {
+            val snapshot = withContext(Dispatchers.IO) {
+                CodexAuthJsonImporter.accountSnapshot(this@CardRunActivity)
+            }
+            if (snapshot.accounts.isEmpty()) {
+                Toast.makeText(
+                    this@CardRunActivity,
+                    getString(com.kite.app.R.string.agent_codex_auth_manage_empty),
+                    Toast.LENGTH_LONG,
+                ).show()
+                return@launch
+            }
+            val labels = snapshot.accounts.map { account ->
+                if (account.id == snapshot.activeAccountId) {
+                    getString(com.kite.app.R.string.agent_codex_auth_active_suffix, account.label)
+                } else {
+                    account.label
+                }
+            }.toTypedArray()
+            val selectedIndex = snapshot.accounts.indexOfFirst { it.id == snapshot.activeAccountId }
+            AlertDialog.Builder(this@CardRunActivity)
+                .setTitle(com.kite.app.R.string.agent_codex_auth_manage_title)
+                .setSingleChoiceItems(labels, selectedIndex) { dialog, index ->
+                    val selected = snapshot.accounts[index]
+                    dialog.dismiss()
+                    lifecycleScope.launch {
+                        val result = withContext(Dispatchers.IO) {
+                            CodexAuthJsonImporter.activateAccount(
+                                this@CardRunActivity,
+                                selected.id,
+                            )
+                        }
+                        val message = if (result.success) {
+                            getString(
+                                com.kite.app.R.string.agent_codex_auth_switch_success,
+                                result.accountLabel ?: selected.label,
+                            )
+                        } else {
+                            getString(com.kite.app.R.string.agent_codex_auth_switch_failed)
+                        }
+                        Toast.makeText(this@CardRunActivity, message, Toast.LENGTH_LONG).show()
+                        if (result.success) {
+                            graph.agentOfficialAccountManager.refresh("codex", "chatgpt")
+                            agentSurfaceBinding?.refreshCodexOfficialAccountStatus()
+                        }
+                    }
+                }
+                .setNegativeButton(com.kite.app.R.string.common_cancel, null)
+                .show()
         }
     }
     private val backCallback = object : OnBackPressedCallback(true) {
@@ -447,6 +504,7 @@ class CardRunActivity : AppCompatActivity() {
             onPickCodexAuthJson = {
                 codexAuthJsonPicker.launch(arrayOf("application/json", "text/plain", "application/octet-stream"))
             },
+            onManageCodexAccounts = ::showCodexAccountSwitcher,
             agentRegistry = graph.agentRegistry,
             officialAccountManager = graph.agentOfficialAccountManager,
             agentConfigurationApi = graph.agentConfigurationApi,

--- a/app/src/main/java/com/kite/app/agent/auth/CodexAuthJsonImporter.kt
+++ b/app/src/main/java/com/kite/app/agent/auth/CodexAuthJsonImporter.kt
@@ -8,9 +8,11 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.FileOutputStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import java.security.MessageDigest
 import java.time.Instant
 import java.time.format.DateTimeParseException
 import java.util.Base64
@@ -31,6 +33,26 @@ internal data class CodexAuthImportResult(
     val authBackupCreated: Boolean = false,
     val configBackupCreated: Boolean = false,
     val accountLabel: String? = null,
+    val importedAccountCount: Int = 0,
+    val activeAccountId: String? = null,
+)
+
+internal data class CodexImportedAccount(
+    val id: String,
+    val label: String,
+)
+
+internal data class CodexImportedAccountSnapshot(
+    val containerReady: Boolean = false,
+    val accounts: List<CodexImportedAccount> = emptyList(),
+    val activeAccountId: String? = null,
+)
+
+internal data class CodexAccountSwitchResult(
+    val success: Boolean,
+    val snapshot: CodexImportedAccountSnapshot,
+    val error: CodexAuthImportError? = null,
+    val accountLabel: String? = null,
 )
 
 /**
@@ -44,6 +66,8 @@ internal object CodexAuthJsonImporter {
     private const val MAX_JSON_NODES = 512
     private const val AUTH_PATH = "/root/.codex/auth.json"
     private const val CONFIG_PATH = "/root/.codex/config.toml"
+    private const val ACCOUNT_STORE_DIRECTORY = "kite-json-accounts"
+    private const val ACCOUNT_STORE_VERSION = 1
 
     fun importFromUri(context: Context, uri: Uri): CodexAuthImportResult {
         val payload = runCatching { readLimited(context, uri) }.getOrNull()
@@ -78,6 +102,51 @@ internal object CodexAuthJsonImporter {
         }.getOrElse { CodexAuthImportResult(false, CodexAuthImportError.WRITE_FAILED) }
     }
 
+    fun accountSnapshot(context: Context): CodexImportedAccountSnapshot {
+        val appContext = context.applicationContext
+        val container = WorkSurfaceRuntimeBridge.getSavedContainer(appContext)
+            ?: return CodexImportedAccountSnapshot()
+        val projection = ContainerAgentConfigProjection { container }
+        return runCatching {
+            val authProjection = projection.resolve(AUTH_PATH)
+                ?: return@runCatching CodexImportedAccountSnapshot()
+            snapshotFiles(authProjection.writeFile)
+        }.getOrDefault(CodexImportedAccountSnapshot())
+    }
+
+    fun activateAccount(context: Context, accountId: String): CodexAccountSwitchResult {
+        val appContext = context.applicationContext
+        val container = WorkSurfaceRuntimeBridge.getSavedContainer(appContext)
+            ?: return CodexAccountSwitchResult(
+                success = false,
+                snapshot = CodexImportedAccountSnapshot(),
+                error = CodexAuthImportError.CONTAINER_NOT_READY,
+            )
+        val projection = ContainerAgentConfigProjection { container }
+        return runCatching {
+            val authProjection = projection.resolve(AUTH_PATH)
+                ?: return@runCatching CodexAccountSwitchResult(
+                    success = false,
+                    snapshot = CodexImportedAccountSnapshot(),
+                    error = CodexAuthImportError.CONTAINER_NOT_READY,
+                )
+            val configProjection = projection.resolve(CONFIG_PATH)
+            activateAccountFiles(
+                authFile = authProjection.writeFile,
+                authReadFile = authProjection.readFile,
+                configFile = configProjection?.writeFile,
+                configReadFile = configProjection?.readFile,
+                accountId = accountId,
+            )
+        }.getOrElse {
+            CodexAccountSwitchResult(
+                success = false,
+                snapshot = CodexImportedAccountSnapshot(containerReady = true),
+                error = CodexAuthImportError.WRITE_FAILED,
+            )
+        }
+    }
+
     internal fun importIntoRootfs(
         rootfsDir: File,
         payload: String,
@@ -94,15 +163,38 @@ internal object CodexAuthJsonImporter {
         )
     }
 
-    internal fun parseCredentials(payload: String): ImportedCodexCredentials? {
-        val roots = parseRoots(payload) ?: return null
+    internal fun snapshotRootfs(rootfsDir: File): CodexImportedAccountSnapshot =
+        snapshotFiles(File(rootfsDir, "root/.codex/auth.json"))
+
+    internal fun activateAccountRootfs(
+        rootfsDir: File,
+        accountId: String,
+    ): CodexAccountSwitchResult {
+        val codexDir = File(rootfsDir, "root/.codex")
+        return activateAccountFiles(
+            authFile = File(codexDir, "auth.json"),
+            authReadFile = File(codexDir, "auth.json"),
+            configFile = File(codexDir, "config.toml"),
+            configReadFile = File(codexDir, "config.toml"),
+            accountId = accountId,
+        )
+    }
+
+    internal fun parseCredentials(payload: String): ImportedCodexCredentials? =
+        parseCredentialList(payload).firstOrNull()
+
+    internal fun parseCredentialList(payload: String): List<ImportedCodexCredentials> {
+        val roots = parseRoots(payload) ?: return emptyList()
         val objects = candidateObjects(roots)
+        val credentials = mutableListOf<ImportedCodexCredentials>()
+        val seenTokenSets = mutableSetOf<String>()
         for (candidate in objects) {
             val tokenObject = candidate.optJSONObject("tokens") ?: candidate
             val idToken = tokenObject.firstString("id_token", "idToken") ?: continue
             val accessToken = tokenObject.firstString("access_token", "accessToken") ?: continue
             val refreshToken = tokenObject.firstString("refresh_token", "refreshToken") ?: continue
-            val idClaims = decodeJwtClaims(idToken) ?: return null
+            val idClaims = decodeJwtClaims(idToken) ?: continue
+            if (!seenTokenSets.add("$idToken\u0000$accessToken\u0000$refreshToken")) continue
             val accountId = tokenObject.firstString(
                 "account_id",
                 "accountId",
@@ -114,13 +206,15 @@ internal object CodexAuthJsonImporter {
                 "chatgpt_account_id",
                 "chatgptAccountId",
             ) ?: accountIdFromClaims(idClaims)
-            val lastRefresh = candidate.firstString("last_refresh", "lastRefresh")
+            val lastRefresh = tokenObject.firstString("last_refresh", "lastRefresh")
+                ?.takeIf(::isIsoInstant)
+                ?: candidate.firstString("last_refresh", "lastRefresh")
                 ?.takeIf(::isIsoInstant)
                 ?: roots.firstNotNullOfOrNull { it.firstString("last_refresh", "lastRefresh")?.takeIf(::isIsoInstant) }
-            val email = candidate.firstString("email")
-                ?: roots.firstNotNullOfOrNull { it.firstString("email") }
+            val email = tokenObject.firstString("email")
+                ?: candidate.firstString("email")
                 ?: idClaims.firstString("email")
-            return ImportedCodexCredentials(
+            credentials += ImportedCodexCredentials(
                 idToken = idToken,
                 accessToken = accessToken,
                 refreshToken = refreshToken,
@@ -129,7 +223,7 @@ internal object CodexAuthJsonImporter {
                 email = email,
             )
         }
-        return null
+        return credentials
     }
 
     internal fun parseError(payload: String): CodexAuthImportError {
@@ -211,44 +305,231 @@ internal object CodexAuthJsonImporter {
         payload: String,
         now: Instant,
     ): CodexAuthImportResult {
-        val credentials = parseCredentials(payload)
-            ?: return CodexAuthImportResult(false, parseError(payload))
-        val authExisted = authBackupSource.isFile
-        val configExisted = configBackupSource?.isFile == true
-        var authBackup: File? = null
-        var configBackup: File? = null
+        val importedCredentials = parseCredentialList(payload)
+        if (importedCredentials.isEmpty()) {
+            return CodexAuthImportResult(false, parseError(payload))
+        }
+        val store = AccountStore(authFile)
+        val rollbacks = mutableListOf<Pair<File, RollbackSnapshot>>()
         return try {
             val codexDir = authFile.parentFile ?: error("Codex auth directory is unavailable")
             check(codexDir.exists() || codexDir.mkdirs())
-            val backupDir = File(codexDir, "import-backups").apply {
-                check(isDirectory || mkdirs())
-            }
-            val suffix = timestampSuffix(now)
-            authBackup = File(backupDir, "auth.$suffix.json.bak")
-                .takeIf { backupIfPresent(authBackupSource, it) }
-            configBackup = configBackupSource?.let { source ->
-                File(backupDir, "config.$suffix.toml.bak").takeIf { backupIfPresent(source, it) }
-            }
+            initializeStore(store)
+            saveActiveAccount(store, authBackupSource)
 
-            atomicWrite(authFile, buildOfficialAuth(credentials, now).toString(2) + "\n")
+            rollbacks += authFile to createRollbackSnapshot(authBackupSource, codexDir)
+            if (configFile != null && configBackupSource != null) {
+                rollbacks += configFile to createRollbackSnapshot(configBackupSource, codexDir)
+            }
+            rollbacks += store.state to createRollbackSnapshot(store.state, store.directory)
+
+            val importedAccounts = importedCredentials.map { credentials ->
+                val auth = buildOfficialAuth(credentials, now)
+                val id = profileId(credentials, auth)
+                val label = accountLabel(credentials, id)
+                val profileFile = accountFile(store, id)
+                rollbacks += profileFile to createRollbackSnapshot(profileFile, store.directory)
+                writeAccount(store, id, label, auth)
+                CodexImportedAccount(id, label)
+            }
+            val active = importedAccounts.first()
+
+            val activeProfile = readAccount(accountFile(store, active.id))
+                ?: error("Imported account profile is invalid")
+            atomicWrite(authFile, activeProfile.auth.toString(2) + "\n")
             if (configFile?.isFile == true) {
-                val currentConfig = configFile.readText()
+                val currentConfig = configBackupSource?.takeIf(File::isFile)?.readText()
+                    ?: configFile.readText()
                 val activatedConfig = activateBuiltInOpenAiConfig(currentConfig)
                 if (activatedConfig != currentConfig) atomicWrite(configFile, activatedConfig)
             }
+            writeActiveAccountId(store, active.id)
+            val authBackupCreated = rollbacks
+                .firstOrNull { (target, _) -> target == authFile }
+                ?.second
+                ?.existedBefore == true
+            val configBackupCreated = configFile != null && rollbacks
+                .firstOrNull { (target, _) -> target == configFile }
+                ?.second
+                ?.existedBefore == true
+            rollbacks.forEach { it.second.delete() }
             CodexAuthImportResult(
                 success = true,
-                authBackupCreated = authBackup != null,
-                configBackupCreated = configBackup != null,
-                accountLabel = credentials.email
-                    ?: credentials.accountId?.let(::compactAccountLabel),
+                authBackupCreated = authBackupCreated,
+                configBackupCreated = configBackupCreated,
+                accountLabel = active.label,
+                importedAccountCount = importedAccounts.size,
+                activeAccountId = active.id,
             )
         } catch (_: Exception) {
-            restoreAfterFailedImport(authFile, authBackup, authExisted)
-            if (configFile != null) restoreAfterFailedImport(configFile, configBackup, configExisted)
+            rollbacks.asReversed().forEach { (target, snapshot) ->
+                restoreAfterFailedImport(target, snapshot)
+                snapshot.delete()
+            }
             CodexAuthImportResult(false, CodexAuthImportError.WRITE_FAILED)
         }
     }
+
+    @Synchronized
+    private fun activateAccountFiles(
+        authFile: File,
+        authReadFile: File,
+        configFile: File?,
+        configReadFile: File?,
+        accountId: String,
+    ): CodexAccountSwitchResult {
+        val store = AccountStore(authFile)
+        return runCatching {
+            initializeStore(store)
+            val account = readAccount(accountFile(store, accountId))
+                ?: return CodexAccountSwitchResult(
+                    false,
+                    snapshotFiles(authFile),
+                    CodexAuthImportError.INVALID_JSON,
+                )
+            saveActiveAccount(store, authReadFile)
+
+            val codexDir = authFile.parentFile ?: error("Codex auth directory is unavailable")
+            val authRollback = createRollbackSnapshot(authReadFile, codexDir)
+            val configRollback = configReadFile?.let { createRollbackSnapshot(it, codexDir) }
+            val stateRollback = createRollbackSnapshot(store.state, store.directory)
+            try {
+                atomicWrite(authFile, account.auth.toString(2) + "\n")
+                if (configFile != null) {
+                    val currentConfig = configReadFile?.takeIf(File::isFile)?.readText()
+                        ?: configFile.takeIf(File::isFile)?.readText().orEmpty()
+                    val activatedConfig = activateBuiltInOpenAiConfig(currentConfig)
+                    if (activatedConfig != currentConfig || !configFile.isFile) {
+                        atomicWrite(configFile, activatedConfig)
+                    }
+                }
+                writeActiveAccountId(store, account.id)
+                authRollback.delete()
+                configRollback?.delete()
+                stateRollback.delete()
+                CodexAccountSwitchResult(
+                    success = true,
+                    snapshot = snapshotFiles(authFile),
+                    accountLabel = account.label,
+                )
+            } catch (_: Exception) {
+                restoreAfterFailedImport(authFile, authRollback)
+                if (configFile != null && configRollback != null) {
+                    restoreAfterFailedImport(configFile, configRollback)
+                }
+                restoreAfterFailedImport(store.state, stateRollback)
+                authRollback.delete()
+                configRollback?.delete()
+                stateRollback.delete()
+                CodexAccountSwitchResult(
+                    false,
+                    snapshotFiles(authFile),
+                    CodexAuthImportError.WRITE_FAILED,
+                )
+            }
+        }.getOrElse {
+            CodexAccountSwitchResult(
+                false,
+                snapshotFiles(authFile),
+                CodexAuthImportError.WRITE_FAILED,
+            )
+        }
+    }
+
+    private fun snapshotFiles(authFile: File): CodexImportedAccountSnapshot {
+        val store = AccountStore(authFile)
+        val containerReady = authFile.parentFile?.isDirectory == true
+        if (!containerReady || !store.accounts.isDirectory) {
+            return CodexImportedAccountSnapshot(containerReady = containerReady)
+        }
+        val accounts = store.accounts.listFiles()
+            .orEmpty()
+            .filter(File::isFile)
+            .mapNotNull(::readAccount)
+            .map { CodexImportedAccount(it.id, it.label) }
+            .sortedBy { it.label.lowercase() }
+        return CodexImportedAccountSnapshot(
+            containerReady = true,
+            accounts = accounts,
+            activeAccountId = readActiveAccountId(store),
+        )
+    }
+
+    private fun initializeStore(store: AccountStore) {
+        check(store.directory.isDirectory || store.directory.mkdirs())
+        check(store.accounts.isDirectory || store.accounts.mkdirs())
+        secureDirectory(store.directory)
+        secureDirectory(store.accounts)
+    }
+
+    private fun writeAccount(
+        store: AccountStore,
+        id: String,
+        label: String,
+        auth: JSONObject,
+    ) {
+        val wrapper = JSONObject()
+            .put("version", ACCOUNT_STORE_VERSION)
+            .put("id", id)
+            .put("label", label)
+            .put("auth", auth)
+        atomicWrite(accountFile(store, id), wrapper.toString(2) + "\n")
+    }
+
+    private fun readAccount(file: File): StoredAccount? = runCatching {
+        val wrapper = JSONObject(file.readText())
+        val id = wrapper.optString("id").trim().takeIf(String::isNotBlank) ?: return null
+        val label = wrapper.optString("label").trim().takeIf(String::isNotBlank)
+            ?: "JSON account ${id.takeLast(6)}"
+        val auth = wrapper.optJSONObject("auth") ?: return null
+        if (!isOfficialAuth(auth)) return null
+        StoredAccount(id, label, auth)
+    }.getOrNull()
+
+    private fun saveActiveAccount(store: AccountStore, visibleAuth: File) {
+        val activeId = readActiveAccountId(store) ?: return
+        val previous = readAccount(accountFile(store, activeId)) ?: return
+        val refreshed = runCatching { JSONObject(visibleAuth.readText()) }.getOrNull() ?: return
+        if (!isOfficialAuth(refreshed)) return
+        writeAccount(store, activeId, previous.label, refreshed)
+    }
+
+    private fun writeActiveAccountId(store: AccountStore, accountId: String) {
+        val state = JSONObject()
+            .put("version", ACCOUNT_STORE_VERSION)
+            .put("active_account_id", accountId)
+        atomicWrite(store.state, state.toString(2) + "\n")
+    }
+
+    private fun readActiveAccountId(store: AccountStore): String? = runCatching {
+        JSONObject(store.state.readText())
+            .optString("active_account_id")
+            .trim()
+            .takeIf(String::isNotBlank)
+    }.getOrNull()
+
+    private fun accountFile(store: AccountStore, accountId: String): File {
+        require(accountId.matches(Regex("""[a-zA-Z0-9_-]+""")))
+        return File(store.accounts, "$accountId.json")
+    }
+
+    private fun profileId(credentials: ImportedCodexCredentials, auth: JSONObject): String {
+        val stable = credentials.accountId
+            ?: credentials.email
+            ?: decodeJwtClaims(credentials.idToken)?.firstString("sub")
+            ?: auth.optJSONObject("tokens")?.optString("refresh_token").orEmpty()
+        val digest = MessageDigest.getInstance("SHA-256").digest(stable.toByteArray())
+        return "json-${digest.joinToString("") { "%02x".format(it) }.take(16)}"
+    }
+
+    private fun accountLabel(credentials: ImportedCodexCredentials, profileId: String): String =
+        credentials.email
+            ?: credentials.accountId?.let(::compactAccountLabel)
+            ?: "JSON account ${profileId.takeLast(6)}"
+
+    private fun isOfficialAuth(auth: JSONObject): Boolean =
+        auth.optString("auth_mode") == "chatgpt" &&
+            auth.optJSONObject("tokens")?.optString("refresh_token").isNullOrBlank().not()
 
     private fun parseRoots(payload: String): List<JSONObject>? {
         val value = runCatching { JSONObject(payload) }.getOrNull()
@@ -324,37 +605,50 @@ internal object CodexAuthJsonImporter {
         return output.toByteArray()
     }
 
-    private fun backupIfPresent(source: File, destination: File): Boolean {
-        if (!source.isFile) return false
-        source.copyTo(destination, overwrite = false)
-        securePermissions(destination)
-        return true
+    private fun createRollbackSnapshot(source: File, directory: File): RollbackSnapshot {
+        if (!source.isFile) return RollbackSnapshot(null, existedBefore = false)
+        val snapshot = File(
+            directory,
+            ".${source.name}.kite-rollback-${System.nanoTime()}.tmp",
+        )
+        secureCopy(source, snapshot)
+        return RollbackSnapshot(snapshot, existedBefore = true)
     }
 
-    private fun restoreAfterFailedImport(target: File, backup: File?, existedBefore: Boolean) {
+    private fun restoreAfterFailedImport(target: File, snapshot: RollbackSnapshot) {
         runCatching {
-            if (existedBefore && backup?.isFile == true) secureCopy(backup, target)
-            else if (!existedBefore && target.exists()) target.delete()
+            if (snapshot.existedBefore && snapshot.file?.isFile == true) {
+                secureCopy(snapshot.file, target)
+            } else if (!snapshot.existedBefore && target.exists()) {
+                target.delete()
+            }
         }
     }
 
     private fun atomicWrite(target: File, content: String) {
         target.parentFile?.mkdirs()
         val temporary = File(target.parentFile, ".${target.name}.${System.nanoTime()}.tmp")
-        temporary.writeText(content)
         try {
-            Files.move(
-                temporary.toPath(),
-                target.toPath(),
-                StandardCopyOption.ATOMIC_MOVE,
-                StandardCopyOption.REPLACE_EXISTING,
-            )
-        } catch (_: Exception) {
-            Files.move(temporary.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+            FileOutputStream(temporary).use { stream ->
+                stream.write(content.toByteArray(StandardCharsets.UTF_8))
+                stream.flush()
+                stream.fd.sync()
+            }
+            securePermissions(temporary)
+            try {
+                Files.move(
+                    temporary.toPath(),
+                    target.toPath(),
+                    StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING,
+                )
+            } catch (_: Exception) {
+                Files.move(temporary.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+            }
+            securePermissions(target)
         } finally {
             temporary.delete()
         }
-        securePermissions(target)
     }
 
     private fun secureCopy(source: File, destination: File) {
@@ -369,6 +663,15 @@ internal object CodexAuthJsonImporter {
         file.setExecutable(false, false)
         file.setReadable(true, true)
         file.setWritable(true, true)
+    }
+
+    private fun secureDirectory(directory: File) {
+        directory.setReadable(false, false)
+        directory.setWritable(false, false)
+        directory.setExecutable(false, false)
+        directory.setReadable(true, true)
+        directory.setWritable(true, true)
+        directory.setExecutable(true, true)
     }
 
     private fun isProviderSection(section: String, provider: String): Boolean {
@@ -389,11 +692,6 @@ internal object CodexAuthJsonImporter {
     private fun compactAccountLabel(accountId: String): String =
         if (accountId.length <= 12) accountId else "${accountId.take(6)}…${accountId.takeLast(4)}"
 
-    private fun timestampSuffix(now: Instant): String = now.toString()
-        .replace(":", "")
-        .replace("-", "")
-        .replace(".", "")
-
     internal data class ImportedCodexCredentials(
         val idToken: String,
         val accessToken: String,
@@ -402,6 +700,27 @@ internal object CodexAuthJsonImporter {
         val lastRefresh: String?,
         val email: String?,
     )
+
+    private data class StoredAccount(
+        val id: String,
+        val label: String,
+        val auth: JSONObject,
+    )
+
+    private data class RollbackSnapshot(
+        val file: File?,
+        val existedBefore: Boolean,
+    ) {
+        fun delete() {
+            file?.delete()
+        }
+    }
+
+    private class AccountStore(authFile: File) {
+        val directory = File(authFile.parentFile, ACCOUNT_STORE_DIRECTORY)
+        val accounts = File(directory, "accounts")
+        val state = File(directory, "state.json")
+    }
 
     private val SESSION_KEYS = setOf("session", "session_json", "sessionJson")
 }

--- a/app/src/main/java/com/kite/app/agent/auth/CodexAuthJsonImporter.kt
+++ b/app/src/main/java/com/kite/app/agent/auth/CodexAuthJsonImporter.kt
@@ -1,0 +1,407 @@
+package com.kite.app.agent.auth
+
+import android.content.Context
+import android.net.Uri
+import com.kite.app.agent.config.ContainerAgentConfigProjection
+import com.kite.app.foundation.workspace.WorkSurfaceRuntimeBridge
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.time.Instant
+import java.time.format.DateTimeParseException
+import java.util.Base64
+
+internal enum class CodexAuthImportError {
+    INVALID_JSON,
+    MISSING_ID_TOKEN,
+    MISSING_ACCESS_TOKEN,
+    MISSING_REFRESH_TOKEN,
+    INVALID_ID_TOKEN,
+    CONTAINER_NOT_READY,
+    WRITE_FAILED,
+}
+
+internal data class CodexAuthImportResult(
+    val success: Boolean,
+    val error: CodexAuthImportError? = null,
+    val authBackupCreated: Boolean = false,
+    val configBackupCreated: Boolean = false,
+    val accountLabel: String? = null,
+)
+
+/**
+ * 把官方 auth.json、CPA 单账号导出和 Sub2API accounts 导出统一成 Codex 原生凭据。
+ *
+ * 认证文件只会写入当前容器的可见/可写 PRoot View，避免直接改 Base rootfs 后活跃 View
+ * 仍然读取旧内容。导入前会备份现有文件，正文不会写入日志、异常消息或结果对象。
+ */
+internal object CodexAuthJsonImporter {
+    private const val MAX_PAYLOAD_BYTES = 1024 * 1024
+    private const val MAX_JSON_NODES = 512
+    private const val AUTH_PATH = "/root/.codex/auth.json"
+    private const val CONFIG_PATH = "/root/.codex/config.toml"
+
+    fun importFromUri(context: Context, uri: Uri): CodexAuthImportResult {
+        val payload = runCatching { readLimited(context, uri) }.getOrNull()
+            ?: return CodexAuthImportResult(false, CodexAuthImportError.INVALID_JSON)
+        return importIntoDefaultContainer(context, payload)
+    }
+
+    fun importIntoDefaultContainer(
+        context: Context,
+        payload: ByteArray,
+        now: Instant = Instant.now(),
+    ): CodexAuthImportResult {
+        if (payload.isEmpty() || payload.size > MAX_PAYLOAD_BYTES) {
+            return CodexAuthImportResult(false, CodexAuthImportError.INVALID_JSON)
+        }
+        val appContext = context.applicationContext
+        val container = WorkSurfaceRuntimeBridge.getSavedContainer(appContext)
+            ?: return CodexAuthImportResult(false, CodexAuthImportError.CONTAINER_NOT_READY)
+        val projection = ContainerAgentConfigProjection { container }
+        return runCatching {
+            val authProjection = projection.resolve(AUTH_PATH)
+                ?: return@runCatching CodexAuthImportResult(false, CodexAuthImportError.CONTAINER_NOT_READY)
+            val configProjection = projection.resolve(CONFIG_PATH)
+            importIntoFiles(
+                authFile = authProjection.writeFile,
+                authBackupSource = authProjection.readFile,
+                configFile = configProjection?.writeFile,
+                configBackupSource = configProjection?.readFile,
+                payload = payload.toString(StandardCharsets.UTF_8),
+                now = now,
+            )
+        }.getOrElse { CodexAuthImportResult(false, CodexAuthImportError.WRITE_FAILED) }
+    }
+
+    internal fun importIntoRootfs(
+        rootfsDir: File,
+        payload: String,
+        now: Instant = Instant.now(),
+    ): CodexAuthImportResult {
+        val codexDir = File(rootfsDir, "root/.codex")
+        return importIntoFiles(
+            authFile = File(codexDir, "auth.json"),
+            authBackupSource = File(codexDir, "auth.json"),
+            configFile = File(codexDir, "config.toml"),
+            configBackupSource = File(codexDir, "config.toml"),
+            payload = payload,
+            now = now,
+        )
+    }
+
+    internal fun parseCredentials(payload: String): ImportedCodexCredentials? {
+        val roots = parseRoots(payload) ?: return null
+        val objects = candidateObjects(roots)
+        for (candidate in objects) {
+            val tokenObject = candidate.optJSONObject("tokens") ?: candidate
+            val idToken = tokenObject.firstString("id_token", "idToken") ?: continue
+            val accessToken = tokenObject.firstString("access_token", "accessToken") ?: continue
+            val refreshToken = tokenObject.firstString("refresh_token", "refreshToken") ?: continue
+            val idClaims = decodeJwtClaims(idToken) ?: return null
+            val accountId = tokenObject.firstString(
+                "account_id",
+                "accountId",
+                "chatgpt_account_id",
+                "chatgptAccountId",
+            ) ?: candidate.firstString(
+                "account_id",
+                "accountId",
+                "chatgpt_account_id",
+                "chatgptAccountId",
+            ) ?: accountIdFromClaims(idClaims)
+            val lastRefresh = candidate.firstString("last_refresh", "lastRefresh")
+                ?.takeIf(::isIsoInstant)
+                ?: roots.firstNotNullOfOrNull { it.firstString("last_refresh", "lastRefresh")?.takeIf(::isIsoInstant) }
+            val email = candidate.firstString("email")
+                ?: roots.firstNotNullOfOrNull { it.firstString("email") }
+                ?: idClaims.firstString("email")
+            return ImportedCodexCredentials(
+                idToken = idToken,
+                accessToken = accessToken,
+                refreshToken = refreshToken,
+                accountId = accountId,
+                lastRefresh = lastRefresh,
+                email = email,
+            )
+        }
+        return null
+    }
+
+    internal fun parseError(payload: String): CodexAuthImportError {
+        val roots = parseRoots(payload) ?: return CodexAuthImportError.INVALID_JSON
+        val objects = candidateObjects(roots)
+        val tokenObject = objects.firstOrNull { candidate ->
+            val tokens = candidate.optJSONObject("tokens") ?: candidate
+            tokens.firstString("id_token", "idToken") != null
+        }?.let { it.optJSONObject("tokens") ?: it }
+            ?: return CodexAuthImportError.MISSING_ID_TOKEN
+        if (tokenObject.firstString("access_token", "accessToken") == null) {
+            return CodexAuthImportError.MISSING_ACCESS_TOKEN
+        }
+        if (tokenObject.firstString("refresh_token", "refreshToken") == null) {
+            return CodexAuthImportError.MISSING_REFRESH_TOKEN
+        }
+        return if (decodeJwtClaims(tokenObject.firstString("id_token", "idToken").orEmpty()) == null) {
+            CodexAuthImportError.INVALID_ID_TOKEN
+        } else {
+            CodexAuthImportError.INVALID_JSON
+        }
+    }
+
+    internal fun buildOfficialAuth(
+        credentials: ImportedCodexCredentials,
+        now: Instant,
+    ): JSONObject = JSONObject()
+        .put("auth_mode", "chatgpt")
+        .put(
+            "tokens",
+            JSONObject()
+                .put("id_token", credentials.idToken)
+                .put("access_token", credentials.accessToken)
+                .put("refresh_token", credentials.refreshToken)
+                .apply { credentials.accountId?.let { put("account_id", it) } },
+        )
+        .put("last_refresh", credentials.lastRefresh ?: now.toString())
+
+    internal fun activateBuiltInOpenAiConfig(config: String): String {
+        if (config.isBlank()) return ""
+        val lines = config.lines()
+        var inTopLevel = true
+        var activeProvider: String? = null
+        val providerPattern = Regex("""^\s*model_provider\s*=\s*[\"']([^\"']+)[\"']\s*(?:#.*)?$""")
+        lines.forEach { line ->
+            if (line.trimStart().startsWith("[")) inTopLevel = false
+            if (inTopLevel && activeProvider == null) {
+                activeProvider = providerPattern.matchEntire(line)?.groupValues?.getOrNull(1)
+            }
+        }
+        val customProvider = activeProvider?.takeUnless { it.equals("openai", ignoreCase = true) }
+        var skippingProviderSection = false
+        var beforeFirstSection = true
+        val output = mutableListOf<String>()
+        lines.forEach { line ->
+            val trimmed = line.trim()
+            val isSection = trimmed.startsWith("[") && trimmed.endsWith("]")
+            if (isSection) {
+                beforeFirstSection = false
+                skippingProviderSection = customProvider != null && isProviderSection(trimmed, customProvider)
+                if (!skippingProviderSection) output += line
+                return@forEach
+            }
+            if (skippingProviderSection) return@forEach
+            if (beforeFirstSection && customProvider != null) {
+                if (trimmed.matches(Regex("""model_provider\s*=.*"""))) return@forEach
+                if (trimmed.matches(Regex("""model\s*=.*"""))) return@forEach
+            }
+            output += line
+        }
+        return output.joinToString("\n").trimEnd() + "\n"
+    }
+
+    private fun importIntoFiles(
+        authFile: File,
+        authBackupSource: File,
+        configFile: File?,
+        configBackupSource: File?,
+        payload: String,
+        now: Instant,
+    ): CodexAuthImportResult {
+        val credentials = parseCredentials(payload)
+            ?: return CodexAuthImportResult(false, parseError(payload))
+        val authExisted = authBackupSource.isFile
+        val configExisted = configBackupSource?.isFile == true
+        var authBackup: File? = null
+        var configBackup: File? = null
+        return try {
+            val codexDir = authFile.parentFile ?: error("Codex auth directory is unavailable")
+            check(codexDir.exists() || codexDir.mkdirs())
+            val backupDir = File(codexDir, "import-backups").apply {
+                check(isDirectory || mkdirs())
+            }
+            val suffix = timestampSuffix(now)
+            authBackup = File(backupDir, "auth.$suffix.json.bak")
+                .takeIf { backupIfPresent(authBackupSource, it) }
+            configBackup = configBackupSource?.let { source ->
+                File(backupDir, "config.$suffix.toml.bak").takeIf { backupIfPresent(source, it) }
+            }
+
+            atomicWrite(authFile, buildOfficialAuth(credentials, now).toString(2) + "\n")
+            if (configFile?.isFile == true) {
+                val currentConfig = configFile.readText()
+                val activatedConfig = activateBuiltInOpenAiConfig(currentConfig)
+                if (activatedConfig != currentConfig) atomicWrite(configFile, activatedConfig)
+            }
+            CodexAuthImportResult(
+                success = true,
+                authBackupCreated = authBackup != null,
+                configBackupCreated = configBackup != null,
+                accountLabel = credentials.email
+                    ?: credentials.accountId?.let(::compactAccountLabel),
+            )
+        } catch (_: Exception) {
+            restoreAfterFailedImport(authFile, authBackup, authExisted)
+            if (configFile != null) restoreAfterFailedImport(configFile, configBackup, configExisted)
+            CodexAuthImportResult(false, CodexAuthImportError.WRITE_FAILED)
+        }
+    }
+
+    private fun parseRoots(payload: String): List<JSONObject>? {
+        val value = runCatching { JSONObject(payload) }.getOrNull()
+        if (value != null) return listOf(value)
+        val array = runCatching { JSONArray(payload) }.getOrNull() ?: return null
+        return buildList {
+            for (index in 0 until array.length()) array.optJSONObject(index)?.let(::add)
+        }.takeIf { it.isNotEmpty() }
+    }
+
+    private fun candidateObjects(roots: List<JSONObject>): List<JSONObject> {
+        val output = ArrayList<JSONObject>()
+        val seen = java.util.Collections.newSetFromMap(java.util.IdentityHashMap<JSONObject, Boolean>())
+        fun visit(value: Any?, depth: Int) {
+            if (value == null || depth > 8 || output.size >= MAX_JSON_NODES) return
+            when (value) {
+                is JSONObject -> {
+                    if (!seen.add(value)) return
+                    output += value
+                    val keys = value.keys()
+                    while (keys.hasNext()) {
+                        val key = keys.next()
+                        val child = value.opt(key)
+                        when (child) {
+                            is JSONObject, is JSONArray -> visit(child, depth + 1)
+                            is String -> if (key in SESSION_KEYS) {
+                                runCatching { JSONObject(child) }.getOrNull()?.let { visit(it, depth + 1) }
+                            }
+                        }
+                    }
+                }
+                is JSONArray -> for (index in 0 until value.length()) visit(value.opt(index), depth + 1)
+            }
+        }
+        roots.forEach { visit(it, 0) }
+        return output
+    }
+
+    private fun decodeJwtClaims(token: String): JSONObject? {
+        val parts = token.split(".")
+        if (parts.size != 3 || parts.any(String::isBlank)) return null
+        return runCatching {
+            val decoded = Base64.getUrlDecoder().decode(parts[1])
+            JSONObject(String(decoded, StandardCharsets.UTF_8))
+        }.getOrNull()
+    }
+
+    private fun accountIdFromClaims(claims: JSONObject): String? =
+        claims.firstString("https://api.openai.com/auth.chatgpt_account_id", "chatgpt_account_id")
+            ?: claims.optJSONObject("https://api.openai.com/auth")
+                ?.firstString("chatgpt_account_id", "account_id")
+
+    private fun JSONObject.firstString(vararg keys: String): String? {
+        keys.forEach { key ->
+            optString(key).trim().takeIf(String::isNotBlank)?.let { return it }
+        }
+        return null
+    }
+
+    private fun readLimited(context: Context, uri: Uri): ByteArray {
+        val output = ByteArrayOutputStream()
+        context.contentResolver.openInputStream(uri)?.use { input ->
+            val buffer = ByteArray(16 * 1024)
+            var total = 0
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                total += read
+                if (total > MAX_PAYLOAD_BYTES) return ByteArray(MAX_PAYLOAD_BYTES + 1)
+                output.write(buffer, 0, read)
+            }
+        } ?: error("Unable to read selected file")
+        return output.toByteArray()
+    }
+
+    private fun backupIfPresent(source: File, destination: File): Boolean {
+        if (!source.isFile) return false
+        source.copyTo(destination, overwrite = false)
+        securePermissions(destination)
+        return true
+    }
+
+    private fun restoreAfterFailedImport(target: File, backup: File?, existedBefore: Boolean) {
+        runCatching {
+            if (existedBefore && backup?.isFile == true) secureCopy(backup, target)
+            else if (!existedBefore && target.exists()) target.delete()
+        }
+    }
+
+    private fun atomicWrite(target: File, content: String) {
+        target.parentFile?.mkdirs()
+        val temporary = File(target.parentFile, ".${target.name}.${System.nanoTime()}.tmp")
+        temporary.writeText(content)
+        try {
+            Files.move(
+                temporary.toPath(),
+                target.toPath(),
+                StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING,
+            )
+        } catch (_: Exception) {
+            Files.move(temporary.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        } finally {
+            temporary.delete()
+        }
+        securePermissions(target)
+    }
+
+    private fun secureCopy(source: File, destination: File) {
+        destination.parentFile?.mkdirs()
+        Files.copy(source.toPath(), destination.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        securePermissions(destination)
+    }
+
+    private fun securePermissions(file: File) {
+        file.setReadable(false, false)
+        file.setWritable(false, false)
+        file.setExecutable(false, false)
+        file.setReadable(true, true)
+        file.setWritable(true, true)
+    }
+
+    private fun isProviderSection(section: String, provider: String): Boolean {
+        val normalized = section.removePrefix("[").removeSuffix("]").trim()
+        val quoted = "model_providers.\"$provider\""
+        val plain = "model_providers.$provider"
+        return normalized == quoted || normalized.startsWith("$quoted.") ||
+            normalized == plain || normalized.startsWith("$plain.")
+    }
+
+    private fun isIsoInstant(value: String): Boolean = try {
+        Instant.parse(value)
+        true
+    } catch (_: DateTimeParseException) {
+        false
+    }
+
+    private fun compactAccountLabel(accountId: String): String =
+        if (accountId.length <= 12) accountId else "${accountId.take(6)}…${accountId.takeLast(4)}"
+
+    private fun timestampSuffix(now: Instant): String = now.toString()
+        .replace(":", "")
+        .replace("-", "")
+        .replace(".", "")
+
+    internal data class ImportedCodexCredentials(
+        val idToken: String,
+        val accessToken: String,
+        val refreshToken: String,
+        val accountId: String?,
+        val lastRefresh: String?,
+        val email: String?,
+    )
+
+    private val SESSION_KEYS = setOf("session", "session_json", "sessionJson")
+}

--- a/app/src/main/java/com/kite/app/feature/runsurface/RunAgentSurfaceBinding.kt
+++ b/app/src/main/java/com/kite/app/feature/runsurface/RunAgentSurfaceBinding.kt
@@ -170,6 +170,7 @@ internal class RunAgentSurfaceBinding(
     private val agentConfigurationApi: AgentConfigurationApi,
     private val agentProviderCatalogApi: AgentProviderCatalogApi,
     private val agentSessionControlApi: AgentSessionControlApi = RuntimeBackedAgentSessionControlApi(),
+    private val onManageCodexAccounts: () -> Unit = {},
 ) : RunSurfaceBinding {
     private val isDark = context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK ==
         Configuration.UI_MODE_NIGHT_YES
@@ -6373,19 +6374,40 @@ internal class RunAgentSurfaceBinding(
                 setPadding(0, ui.dp(4), ui.dp(10), 0)
             })
         }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
-        addView(TextView(context).apply {
-            text = context.getString(R.string.agent_codex_auth_import_action)
+        addView(LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+            addView(
+                codexAuthCardAction(
+                    context.getString(R.string.agent_codex_auth_import_action),
+                    onPickCodexAuthJson,
+                ),
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ui.dp(40)),
+            )
+            addView(
+                codexAuthCardAction(
+                    context.getString(R.string.agent_codex_auth_manage_action),
+                    onManageCodexAccounts,
+                ),
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ui.dp(40)).apply {
+                    topMargin = ui.dp(8)
+                },
+            )
+        }, LinearLayout.LayoutParams(ui.dp(126), ViewGroup.LayoutParams.WRAP_CONTENT))
+    }
+
+    private fun codexAuthCardAction(label: String, onClick: () -> Unit): TextView =
+        TextView(context).apply {
+            text = label
             textSize = 13.5f
             typeface = Typeface.DEFAULT_BOLD
             gravity = Gravity.CENTER
             setTextColor(tokens.textPrimary)
-            setPadding(ui.dp(12), 0, ui.dp(12), 0)
+            setPadding(ui.dp(10), 0, ui.dp(10), 0)
             background = ui.roundedBox(agentSurface, tokens.border, ui.dp(16).toFloat(), ui.dp(1))
             isClickable = true
             isFocusable = true
-            setOnClickListener { onPickCodexAuthJson() }
-        }, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ui.dp(40)))
-    }
+            setOnClickListener { onClick() }
+        }
 
     fun refreshCodexOfficialAccountStatus() {
         officialAccountManager.refresh("codex", "chatgpt")

--- a/app/src/main/java/com/kite/app/feature/runsurface/RunAgentSurfaceBinding.kt
+++ b/app/src/main/java/com/kite/app/feature/runsurface/RunAgentSurfaceBinding.kt
@@ -164,6 +164,7 @@ internal class RunAgentSurfaceBinding(
     private val onCloseInstance: () -> Unit,
     private val onPickImages: () -> Unit,
     private val onPickFiles: () -> Unit,
+    private val onPickCodexAuthJson: () -> Unit,
     private val agentRegistry: KiteAgentRegistry,
     private val officialAccountManager: AgentOfficialAccountManager,
     private val agentConfigurationApi: AgentConfigurationApi,
@@ -5637,6 +5638,12 @@ internal class RunAgentSurfaceBinding(
                     setTextColor(tokens.textSecondary)
                     setPadding(0, ui.dp(5), 0, ui.dp(13))
                 })
+                if (providerLibraryMode == AgentProviderLibraryMode.Browse && targetAgentId == "codex") {
+                    addView(buildCodexAuthImportCard(), LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ).apply { bottomMargin = ui.dp(12) })
+                }
                 if (providerLibraryMode == AgentProviderLibraryMode.Browse) {
                     addView(buildProviderGroupStrip(
                         selected,
@@ -6339,6 +6346,49 @@ internal class RunAgentSurfaceBinding(
                 else -> officialAccountManager.login(agentId, account.id)
             }
         }
+    }
+
+    private fun buildCodexAuthImportCard(): View = LinearLayout(context).apply {
+        orientation = LinearLayout.HORIZONTAL
+        gravity = Gravity.CENTER_VERTICAL
+        setPadding(ui.dp(16), ui.dp(12), ui.dp(10), ui.dp(12))
+        background = ui.roundedBox(
+            agentSettingsSurface,
+            tokens.border,
+            ui.dp(18).toFloat(),
+            ui.dp(1),
+        )
+        addView(LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+            addView(TextView(context).apply {
+                text = context.getString(R.string.agent_codex_auth_import_title)
+                textSize = 15f
+                typeface = Typeface.DEFAULT_BOLD
+                setTextColor(tokens.textPrimary)
+            })
+            addView(TextView(context).apply {
+                text = context.getString(R.string.agent_codex_auth_import_summary)
+                textSize = 12.5f
+                setTextColor(tokens.textSecondary)
+                setPadding(0, ui.dp(4), ui.dp(10), 0)
+            })
+        }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+        addView(TextView(context).apply {
+            text = context.getString(R.string.agent_codex_auth_import_action)
+            textSize = 13.5f
+            typeface = Typeface.DEFAULT_BOLD
+            gravity = Gravity.CENTER
+            setTextColor(tokens.textPrimary)
+            setPadding(ui.dp(12), 0, ui.dp(12), 0)
+            background = ui.roundedBox(agentSurface, tokens.border, ui.dp(16).toFloat(), ui.dp(1))
+            isClickable = true
+            isFocusable = true
+            setOnClickListener { onPickCodexAuthJson() }
+        }, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ui.dp(40)))
+    }
+
+    fun refreshCodexOfficialAccountStatus() {
+        officialAccountManager.refresh("codex", "chatgpt")
     }
 
     private fun AgentOfficialAccountStatus.officialAccountLabel(): String = when (this) {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -9,6 +9,10 @@
     <string name="common_retry">Retry</string>
     <string name="common_more">More</string>
     <string name="common_cancel">Cancel</string>
+    <string name="agent_codex_auth_import_title">Import Codex JSON auth</string>
+    <string name="agent_codex_auth_import_summary">Supports official auth.json, CPA single-account, and Sub2API accounts exports; processed locally only.</string>
+    <string name="agent_codex_auth_import_action">Choose JSON</string>
+    <string name="agent_codex_auth_import_success">Codex authentication imported and activated; existing auth and config were backed up.</string>
 
     <string name="settings_title">Settings</string>
     <string name="settings_section_personalization">Personalization</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -10,9 +10,15 @@
     <string name="common_more">More</string>
     <string name="common_cancel">Cancel</string>
     <string name="agent_codex_auth_import_title">Import Codex JSON auth</string>
-    <string name="agent_codex_auth_import_summary">Supports official auth.json, CPA single-account, and Sub2API accounts exports; processed locally only.</string>
-    <string name="agent_codex_auth_import_action">Choose JSON</string>
-    <string name="agent_codex_auth_import_success">Codex authentication imported and activated; existing auth and config were backed up.</string>
+    <string name="agent_codex_auth_import_summary">Supports official, CPA, and Sub2API multi-account exports; accounts stay in the active container and can be switched.</string>
+    <string name="agent_codex_auth_import_action">Import accounts</string>
+    <string name="agent_codex_auth_import_success">Imported %1$d Codex account(s) and activated the first account.</string>
+    <string name="agent_codex_auth_manage_action">Switch account</string>
+    <string name="agent_codex_auth_manage_title">Choose Codex account</string>
+    <string name="agent_codex_auth_manage_empty">No imported Codex accounts yet.</string>
+    <string name="agent_codex_auth_switch_success">Switched to %1$s.</string>
+    <string name="agent_codex_auth_switch_failed">Could not switch Codex account. Check the container state.</string>
+    <string name="agent_codex_auth_active_suffix">%1$s (current)</string>
 
     <string name="settings_title">Settings</string>
     <string name="settings_section_personalization">Personalization</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,9 +9,15 @@
     <string name="common_more">更多</string>
     <string name="common_cancel">取消</string>
     <string name="agent_codex_auth_import_title">导入 Codex JSON 认证</string>
-    <string name="agent_codex_auth_import_summary">支持官方 auth.json、CPA 单账号和 Sub2API accounts 导出；文件只在本机处理。</string>
-    <string name="agent_codex_auth_import_action">选择 JSON</string>
-    <string name="agent_codex_auth_import_success">Codex 认证已导入并激活；现有认证和配置已备份。</string>
+    <string name="agent_codex_auth_import_summary">支持官方、CPA、Sub2API 多账号导出；账号保存在当前容器并可随时切换。</string>
+    <string name="agent_codex_auth_import_action">导入账号</string>
+    <string name="agent_codex_auth_import_success">已导入 %1$d 个 Codex 账号并激活第一个账号。</string>
+    <string name="agent_codex_auth_manage_action">切换账号</string>
+    <string name="agent_codex_auth_manage_title">选择 Codex 账号</string>
+    <string name="agent_codex_auth_manage_empty">还没有已导入的 Codex 账号。</string>
+    <string name="agent_codex_auth_switch_success">已切换到 %1$s。</string>
+    <string name="agent_codex_auth_switch_failed">Codex 账号切换失败，请检查容器状态。</string>
+    <string name="agent_codex_auth_active_suffix">%1$s（当前）</string>
 
     <string name="settings_title">设置</string>
     <string name="settings_section_personalization">个性化</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,10 @@
     <string name="common_retry">重试</string>
     <string name="common_more">更多</string>
     <string name="common_cancel">取消</string>
+    <string name="agent_codex_auth_import_title">导入 Codex JSON 认证</string>
+    <string name="agent_codex_auth_import_summary">支持官方 auth.json、CPA 单账号和 Sub2API accounts 导出；文件只在本机处理。</string>
+    <string name="agent_codex_auth_import_action">选择 JSON</string>
+    <string name="agent_codex_auth_import_success">Codex 认证已导入并激活；现有认证和配置已备份。</string>
 
     <string name="settings_title">设置</string>
     <string name="settings_section_personalization">个性化</string>

--- a/app/src/test/kotlin/com/kite/app/agent/auth/CodexAuthJsonImporterTest.kt
+++ b/app/src/test/kotlin/com/kite/app/agent/auth/CodexAuthJsonImporterTest.kt
@@ -1,0 +1,154 @@
+package com.kite.app.agent.auth
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+import java.time.Instant
+import java.util.Base64
+
+@RunWith(RobolectricTestRunner::class)
+class CodexAuthJsonImporterTest {
+    @get:Rule
+    val temp = TemporaryFolder()
+
+    @Test
+    fun `official and CPA credentials activate built in Codex provider`() {
+        val rootfs = temp.newFolder("rootfs")
+        val codexDir = File(rootfs, "root/.codex").apply { mkdirs() }
+        File(codexDir, "auth.json").writeText("""{"OPENAI_API_KEY":"old-key"}""")
+        File(codexDir, "config.toml").writeText(
+            """
+            model_provider = "custom"
+            model = "third-party-model"
+            model_reasoning_effort = "high"
+
+            [model_providers.custom]
+            name = "custom"
+            base_url = "https://example.test/v1"
+
+            [projects."/workspace"]
+            trust_level = "trusted"
+            """.trimIndent() + "\n",
+        )
+        val idToken = jwt("""{"sub":"official-user","email":"official@example.test"}""")
+        val payload = JSONObject()
+            .put("id_token", idToken)
+            .put("access_token", "access")
+            .put("refresh_token", "refresh")
+            .put("account_id", "official-account")
+            .put("last_refresh", "2026-07-26T12:00:00Z")
+            .toString()
+
+        val result = CodexAuthJsonImporter.importIntoRootfs(
+            rootfs,
+            payload,
+            Instant.parse("2026-07-26T13:00:00Z"),
+        )
+
+        assertTrue(result.success)
+        assertTrue(result.authBackupCreated)
+        assertTrue(result.configBackupCreated)
+        val auth = JSONObject(File(codexDir, "auth.json").readText())
+        assertEquals("chatgpt", auth.getString("auth_mode"))
+        assertEquals("official-account", auth.getJSONObject("tokens").getString("account_id"))
+        val config = File(codexDir, "config.toml").readText()
+        assertFalse(config.contains("model_provider"))
+        assertFalse(config.contains("third-party-model"))
+        assertFalse(config.contains("[model_providers.custom]"))
+        assertTrue(config.contains("model_reasoning_effort = \"high\""))
+        assertTrue(config.contains("[projects.\"/workspace\"]"))
+    }
+
+    @Test
+    fun `Sub2API accounts export is normalized from nested credentials`() {
+        val rootfs = temp.newFolder("sub2api-rootfs")
+        val idToken = jwt("""{"sub":"sub2api-user","email":"sub2api@example.test"}""")
+        val payload = JSONObject()
+            .put("exported_at", "2026-08-05T00:00:00Z")
+            .put("proxies", JSONArray())
+            .put(
+                "accounts",
+                JSONArray().put(
+                    JSONObject()
+                        .put("name", "sub2api-account")
+                        .put("type", "codex")
+                        .put(
+                            "credentials",
+                            JSONObject()
+                                .put("access_token", "access")
+                                .put("expires_at", "2026-08-06T00:00:00Z")
+                                .put("refresh_token", "refresh")
+                                .put("id_token", idToken)
+                                .put("email", "sub2api@example.test")
+                                .put("chatgpt_account_id", "sub2api-account-id"),
+                        ),
+                ),
+            )
+            .put("type", "sub2api")
+            .put("version", 1)
+            .toString()
+
+        val result = CodexAuthJsonImporter.importIntoRootfs(rootfs, payload)
+
+        assertTrue(result.success)
+        assertEquals("sub2api@example.test", result.accountLabel)
+        assertEquals(
+            "sub2api-account-id",
+            JSONObject(File(rootfs, "root/.codex/auth.json").readText())
+                .getJSONObject("tokens")
+                .getString("account_id"),
+        )
+    }
+
+    @Test
+    fun `wrapped session and CPA array are accepted`() {
+        val idToken = jwt("""{"sub":"array-user"}""")
+        val nested = JSONObject()
+            .put("tokens", JSONObject()
+                .put("id_token", idToken)
+                .put("access_token", "access")
+                .put("refresh_token", "refresh")
+                .put("account_id", "array-account"))
+        val wrapped = JSONObject().put("session_json", nested.toString()).toString()
+        assertEquals("array-account", CodexAuthJsonImporter.parseCredentials(wrapped)?.accountId)
+
+        val array = JSONArray().put(
+            JSONObject()
+                .put("id_token", idToken)
+                .put("access_token", "access")
+                .put("refresh_token", "refresh")
+                .put("account_id", "array-account"),
+        ).toString()
+        assertEquals("array-account", CodexAuthJsonImporter.parseCredentials(array)?.accountId)
+    }
+
+    @Test
+    fun `missing refresh token is rejected without writing auth`() {
+        val rootfs = temp.newFolder("invalid-rootfs")
+        val payload = JSONObject()
+            .put("id_token", jwt("""{"sub":"user"}"""))
+            .put("access_token", "access")
+            .toString()
+
+        val result = CodexAuthJsonImporter.importIntoRootfs(rootfs, payload)
+
+        assertFalse(result.success)
+        assertEquals(CodexAuthImportError.MISSING_REFRESH_TOKEN, result.error)
+        assertFalse(File(rootfs, "root/.codex/auth.json").exists())
+    }
+
+    private fun jwt(payload: String): String {
+        val encoder = Base64.getUrlEncoder().withoutPadding()
+        val header = encoder.encodeToString("""{"alg":"none","typ":"JWT"}""".toByteArray())
+        val body = encoder.encodeToString(payload.toByteArray())
+        return "$header.$body.signature"
+    }
+}

--- a/app/src/test/kotlin/com/kite/app/agent/auth/CodexAuthJsonImporterTest.kt
+++ b/app/src/test/kotlin/com/kite/app/agent/auth/CodexAuthJsonImporterTest.kt
@@ -54,6 +54,7 @@ class CodexAuthJsonImporterTest {
         )
 
         assertTrue(result.success)
+        assertEquals(1, result.importedAccountCount)
         assertTrue(result.authBackupCreated)
         assertTrue(result.configBackupCreated)
         val auth = JSONObject(File(codexDir, "auth.json").readText())
@@ -68,29 +69,38 @@ class CodexAuthJsonImporterTest {
     }
 
     @Test
-    fun `Sub2API accounts export is normalized from nested credentials`() {
+    fun `Sub2API accounts export stores every account and supports switching`() {
         val rootfs = temp.newFolder("sub2api-rootfs")
-        val idToken = jwt("""{"sub":"sub2api-user","email":"sub2api@example.test"}""")
+        val firstIdToken = jwt("""{"sub":"sub2api-user-1","email":"first@example.test"}""")
+        val secondIdToken = jwt("""{"sub":"sub2api-user-2","email":"second@example.test"}""")
         val payload = JSONObject()
             .put("exported_at", "2026-08-05T00:00:00Z")
             .put("proxies", JSONArray())
             .put(
                 "accounts",
-                JSONArray().put(
-                    JSONObject()
-                        .put("name", "sub2api-account")
-                        .put("type", "codex")
-                        .put(
+                JSONArray()
+                    .put(
+                        JSONObject().put(
                             "credentials",
                             JSONObject()
-                                .put("access_token", "access")
-                                .put("expires_at", "2026-08-06T00:00:00Z")
-                                .put("refresh_token", "refresh")
-                                .put("id_token", idToken)
-                                .put("email", "sub2api@example.test")
-                                .put("chatgpt_account_id", "sub2api-account-id"),
+                                .put("access_token", "access-1")
+                                .put("refresh_token", "refresh-1")
+                                .put("id_token", firstIdToken)
+                                .put("email", "first@example.test")
+                                .put("chatgpt_account_id", "sub2api-account-1"),
                         ),
-                ),
+                    )
+                    .put(
+                        JSONObject().put(
+                            "credentials",
+                            JSONObject()
+                                .put("access_token", "access-2")
+                                .put("refresh_token", "refresh-2")
+                                .put("id_token", secondIdToken)
+                                .put("email", "second@example.test")
+                                .put("chatgpt_account_id", "sub2api-account-2"),
+                        ),
+                    ),
             )
             .put("type", "sub2api")
             .put("version", 1)
@@ -99,9 +109,24 @@ class CodexAuthJsonImporterTest {
         val result = CodexAuthJsonImporter.importIntoRootfs(rootfs, payload)
 
         assertTrue(result.success)
-        assertEquals("sub2api@example.test", result.accountLabel)
+        assertEquals(2, result.importedAccountCount)
+        assertEquals("first@example.test", result.accountLabel)
         assertEquals(
-            "sub2api-account-id",
+            "sub2api-account-1",
+            JSONObject(File(rootfs, "root/.codex/auth.json").readText())
+                .getJSONObject("tokens")
+                .getString("account_id"),
+        )
+
+        val snapshot = CodexAuthJsonImporter.snapshotRootfs(rootfs)
+        assertEquals(2, snapshot.accounts.size)
+        val second = snapshot.accounts.single { it.label == "second@example.test" }
+        val switch = CodexAuthJsonImporter.activateAccountRootfs(rootfs, second.id)
+
+        assertTrue(switch.success)
+        assertEquals(second.id, switch.snapshot.activeAccountId)
+        assertEquals(
+            "sub2api-account-2",
             JSONObject(File(rootfs, "root/.codex/auth.json").readText())
                 .getJSONObject("tokens")
                 .getString("account_id"),


### PR DESCRIPTION
## Summary

This is a follow-up PR to #8 for the broader account-import workflow.

- Accept the flat official/CPA credential export shape used by the supplied JSON files.
- Accept nested session/wrapper objects and Sub2API `accounts[].credentials` exports.
- Normalize each supported credential set to Codex's native ChatGPT auth shape.
- Persist one owner-only account profile per imported account in the active container under `~/.codex/kite-json-accounts/accounts/`.
- Keep the active account in `state.json`; the Codex provider page offers import and account switching.
- Before switching, save any refreshed current credentials back to the active profile.
- Use same-directory atomic writes and temporary rollback snapshots; rollback snapshots are deleted after the operation.

## Consumption lifecycle

The profiles are intentionally long-lived because the account-switch action consumes them later. Import stores all valid accounts and activates the first one; the provider page's Switch account action reads the profile list and activates the selected profile. Profiles remain until a later account-management/delete operation removes them or the container is removed. They are not generic backups.

## Security boundary

- Credential values are never logged, uploaded, or included in tests.
- Profile files and state are owner-only within the container.
- No proxy behavior or network routing is changed by this PR.
- This is deliberately separate from #8 so the maintainer can accept the official-only path first, then review the multi-account and format adapters independently.

## Verification

- `./gradlew :app:compileDebugKotlin --no-daemon --offline --max-workers=1` — passed.
- `./gradlew :app:assembleDebug --no-daemon --offline --max-workers=1` — passed.
- Debug APK installed on USB device `LZWCUOVKAE5XGY65`; the device reached the main UI after installing the complete runtime bundle. Logs confirm the latest rootfs, PRoot, and supervisor startup succeeded.
- Added Robolectric coverage for multi-account Sub2API import, profile listing, and account switching.
- Targeted unit-test execution remains blocked before test execution by the environment's Gradle 8.14 `debugUnitTestRuntimeClasspath` ConcurrentModificationException.

Follow-up to #8.