### PR TITLE
feat(accounts): save and switch official agent accounts

### DIFF
--- a/app/src/main/java/com/kite/app/agent/auth/AgentOfficialAccountManager.kt
+++ b/app/src/main/java/com/kite/app/agent/auth/AgentOfficialAccountManager.kt
@@ -323,15 +323,8 @@ internal class AgentOfficialAccountManager(
         ) {
             return AgentOfficialAccountOperationResult.Unsupported("当前 Agent 不支持保存官方账号")
         }
-        val identity = when (val result = adapter.currentIdentity(agentId)) {
-            is AgentAccountIdentityResult.Ready -> result.identity
-            is AgentAccountIdentityResult.Unavailable ->
-                return AgentOfficialAccountOperationResult.Failed(result.message)
-            is AgentAccountIdentityResult.Failed ->
-                return AgentOfficialAccountOperationResult.Failed(result.message)
-        }
-        val credential = when (val result = adapter.captureCurrent(agentId)) {
-            is AgentAccountCredentialReadResult.Ready -> result.snapshot
+        val captured = when (val result = adapter.captureCurrent(agentId)) {
+            is AgentAccountCredentialReadResult.Ready -> result
             is AgentAccountCredentialReadResult.Missing ->
                 return AgentOfficialAccountOperationResult.Failed(result.message)
             is AgentAccountCredentialReadResult.Unavailable ->
@@ -339,6 +332,8 @@ internal class AgentOfficialAccountManager(
             is AgentAccountCredentialReadResult.Failed ->
                 return AgentOfficialAccountOperationResult.Failed(result.message)
         }
+        val identity = captured.identity
+        val credential = captured.snapshot
         val existing = savedAccounts(agentId).firstOrNull { it.accountId == identity.accountId }
             ?: withContext(storageDispatcher) { vault.account(agentId, identity.accountId) }
         val now = System.currentTimeMillis()
@@ -372,17 +367,48 @@ internal class AgentOfficialAccountManager(
         }
         val target = withContext(storageDispatcher) { vault.account(agentId, targetAccountId) }
             ?: return AgentOfficialAccountOperationResult.Failed("目标账号档案不存在")
-        val targetCredential = withContext(storageDispatcher) {
-            vault.credential(agentId, targetAccountId)
-        } ?: return AgentOfficialAccountOperationResult.Failed("目标账号凭据不可用")
-        val before = when (val result = adapter.captureCurrent(agentId)) {
-            is AgentAccountCredentialReadResult.Ready -> result.snapshot
+        val captured = when (val result = adapter.captureCurrent(agentId)) {
+            is AgentAccountCredentialReadResult.Ready -> result
             is AgentAccountCredentialReadResult.Missing ->
                 return AgentOfficialAccountOperationResult.Failed("切换前无法取得当前凭据，已停止切换")
             is AgentAccountCredentialReadResult.Unavailable ->
                 return AgentOfficialAccountOperationResult.Failed(result.message)
             is AgentAccountCredentialReadResult.Failed ->
                 return AgentOfficialAccountOperationResult.Failed(result.message)
+        }
+        val before = captured.snapshot
+        val currentIdentity = captured.identity
+        val targetCredential = withContext(storageDispatcher) {
+            vault.credential(agentId, targetAccountId)
+        } ?: return AgentOfficialAccountOperationResult.Failed("目标账号凭据不可用")
+        val currentSaved = withContext(storageDispatcher) {
+            vault.account(agentId, currentIdentity.accountId)
+        }
+        if (currentSaved != null) {
+            try {
+                withContext(storageDispatcher) { vault.save(currentSaved, before) }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Throwable) {
+                return AgentOfficialAccountOperationResult.Failed(
+                    "无法更新当前账号最新凭据，已停止切换",
+                    restored = true,
+                )
+            }
+        }
+        if (currentIdentity.accountId == targetAccountId) {
+            return try {
+                withContext(storageDispatcher) { vault.markCurrent(agentId, targetAccountId) }
+                updateSavedCache(agentId)
+                AgentOfficialAccountOperationResult.Switched(target)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Throwable) {
+                AgentOfficialAccountOperationResult.Failed(
+                    "无法同步当前账号档案",
+                    restored = true,
+                )
+            }
         }
         var nativeChanged = false
         return try {

--- a/app/src/main/java/com/kite/app/agent/auth/AgentOfficialAccountManager.kt
+++ b/app/src/main/java/com/kite/app/agent/auth/AgentOfficialAccountManager.kt
@@ -3,16 +3,25 @@ package com.kite.app.agent.auth
 import com.kite.app.agent.registration.AgentOfficialAccountCommand
 import com.kite.app.agent.registration.AgentOfficialAccountSpec
 import com.kite.app.agent.registration.KiteAgentRegistry
+import com.kite.app.agent.sdk.account.AgentAccountCapability
+import com.kite.app.agent.sdk.account.AgentAccountCredentialReadResult
+import com.kite.app.agent.sdk.account.AgentAccountCredentialWriteResult
+import com.kite.app.agent.sdk.account.AgentAccountIdentityResult
+import com.kite.app.agent.sdk.account.AgentOfficialAccountAdapter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.launch
 
 data class AgentOfficialAccountKey(
@@ -29,6 +38,9 @@ enum class AgentOfficialAccountStatus {
     SigningIn,
     CancellingLogin,
     SigningOut,
+    Saving,
+    Switching,
+    Deleting,
     Failed,
 }
 
@@ -42,6 +54,14 @@ data class AgentOfficialAccountCommandResult(
     val output: String,
 )
 
+internal sealed interface AgentOfficialAccountOperationResult {
+    data class Saved(val account: AgentSavedOfficialAccount) : AgentOfficialAccountOperationResult
+    data class Switched(val account: AgentSavedOfficialAccount) : AgentOfficialAccountOperationResult
+    data object Deleted : AgentOfficialAccountOperationResult
+    data class Unsupported(val message: String) : AgentOfficialAccountOperationResult
+    data class Failed(val message: String, val restored: Boolean = false) : AgentOfficialAccountOperationResult
+}
+
 fun interface AgentOfficialAccountCommandRunner {
     suspend fun run(command: AgentOfficialAccountCommand): AgentOfficialAccountCommandResult
 }
@@ -51,21 +71,135 @@ fun interface AgentOfficialAccountCommandRunner {
  *
  * 账号凭据始终由 Agent 原生 CLI 保存；本类只运行资源声明的动作并投影状态。
  */
-class AgentOfficialAccountManager(
+internal class AgentOfficialAccountManager(
     private val scope: CoroutineScope,
     private val registry: KiteAgentRegistry,
     private val commandRunner: AgentOfficialAccountCommandRunner,
+    private val accountAdapterResolver: ((String) -> AgentOfficialAccountAdapter?)? = null,
+    private val vault: AgentOfficialAccountVault? = null,
+    private val storageDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
     private val mutableStates = MutableStateFlow<Map<AgentOfficialAccountKey, AgentOfficialAccountState>>(emptyMap())
+    private val mutableSavedAccounts = MutableStateFlow<Map<String, List<AgentSavedOfficialAccount>>>(emptyMap())
+    private val mutableCurrentAccountIds = MutableStateFlow<Map<String, String?>>(emptyMap())
     private val activeJobs = mutableMapOf<AgentOfficialAccountKey, Job>()
+    private val loadedAgentIds = mutableSetOf<String>()
 
     val states: StateFlow<Map<AgentOfficialAccountKey, AgentOfficialAccountState>> = mutableStates.asStateFlow()
+    val savedAccounts: StateFlow<Map<String, List<AgentSavedOfficialAccount>>> =
+        mutableSavedAccounts.asStateFlow()
+    val currentAccountIds: StateFlow<Map<String, String?>> = mutableCurrentAccountIds.asStateFlow()
 
     fun accounts(agentId: String): List<AgentOfficialAccountSpec> =
         registry.snapshot().entry(agentId)?.registration?.officialAccounts.orEmpty()
 
     fun state(agentId: String, accountId: String): AgentOfficialAccountState =
         states.value[AgentOfficialAccountKey(agentId, accountId)] ?: AgentOfficialAccountState()
+
+    fun savedAccounts(agentId: String): List<AgentSavedOfficialAccount> =
+        savedAccounts.value[agentId].orEmpty()
+
+    fun currentSavedAccountId(agentId: String): String? =
+        mutableCurrentAccountIds.value[agentId]
+
+    fun loadSavedAccounts(agentId: String) {
+        if (vault == null) return
+        synchronized(loadedAgentIds) {
+            if (!loadedAgentIds.add(agentId)) return
+        }
+        scope.launch {
+            val accounts = withContext(storageDispatcher) { vault.accounts(agentId) }
+            val currentId = withContext(storageDispatcher) { vault.currentAccountId(agentId) }
+            mutableSavedAccounts.update { current -> current + (agentId to accounts) }
+            mutableCurrentAccountIds.update { current -> current + (agentId to currentId) }
+        }
+    }
+
+    fun accountCapabilities(agentId: String) =
+        accountAdapterResolver?.invoke(agentId)?.accountCapabilities()
+
+    fun saveCurrent(
+        agentId: String,
+        accountId: String,
+        onResult: (AgentOfficialAccountOperationResult) -> Unit = {},
+    ) {
+        val account = account(agentId, accountId) ?: return
+        launch(account, agentId, AgentOfficialAccountStatus.Saving) {
+            val result = saveCurrentAccount(agentId, account)
+            onResult(result)
+            when (result) {
+                is AgentOfficialAccountOperationResult.Saved -> AgentOfficialAccountState(
+                    AgentOfficialAccountStatus.LoggedIn,
+                    "已保存当前账号",
+                )
+                is AgentOfficialAccountOperationResult.Unsupported -> AgentOfficialAccountState(
+                    AgentOfficialAccountStatus.Failed,
+                    result.message,
+                )
+                is AgentOfficialAccountOperationResult.Failed -> AgentOfficialAccountState(
+                    AgentOfficialAccountStatus.Failed,
+                    result.message,
+                )
+                else -> AgentOfficialAccountState(AgentOfficialAccountStatus.Failed, "账号操作未完成")
+            }
+        }
+    }
+
+    fun switchTo(
+        agentId: String,
+        loginAccountId: String,
+        savedAccountId: String,
+        onResult: (AgentOfficialAccountOperationResult) -> Unit = {},
+    ) {
+        val account = account(agentId, loginAccountId) ?: return
+        launch(account, agentId, AgentOfficialAccountStatus.Switching) {
+            val result = switchSavedAccount(agentId, savedAccountId)
+            onResult(result)
+            when (result) {
+                is AgentOfficialAccountOperationResult.Switched -> AgentOfficialAccountState(
+                    AgentOfficialAccountStatus.LoggedIn,
+                    "已切换账号",
+                )
+                is AgentOfficialAccountOperationResult.Unsupported -> AgentOfficialAccountState(
+                    AgentOfficialAccountStatus.Failed,
+                    result.message,
+                )
+                is AgentOfficialAccountOperationResult.Failed -> AgentOfficialAccountState(
+                    AgentOfficialAccountStatus.Failed,
+                    result.message,
+                )
+                else -> AgentOfficialAccountState(AgentOfficialAccountStatus.Failed, "账号操作未完成")
+            }
+        }
+    }
+
+    fun deleteSaved(
+        agentId: String,
+        loginAccountId: String,
+        savedAccountId: String,
+        onResult: (AgentOfficialAccountOperationResult) -> Unit = {},
+    ) {
+        val account = account(agentId, loginAccountId) ?: return
+        launch(account, agentId, AgentOfficialAccountStatus.Deleting) {
+            val result = deleteSavedAccount(agentId, savedAccountId)
+            onResult(result)
+            when (result) {
+                AgentOfficialAccountOperationResult.Deleted -> AgentOfficialAccountState(
+                    AgentOfficialAccountStatus.LoggedIn,
+                    "已删除账号档案",
+                )
+                is AgentOfficialAccountOperationResult.Unsupported -> AgentOfficialAccountState(
+                    AgentOfficialAccountStatus.Failed,
+                    result.message,
+                )
+                is AgentOfficialAccountOperationResult.Failed -> AgentOfficialAccountState(
+                    AgentOfficialAccountStatus.Failed,
+                    result.message,
+                )
+                else -> AgentOfficialAccountState(AgentOfficialAccountStatus.Failed, "账号操作未完成")
+            }
+        }
+    }
 
     fun refresh(agentId: String, accountId: String) {
         val account = account(agentId, accountId) ?: return
@@ -83,7 +217,7 @@ class AgentOfficialAccountManager(
                 false -> AgentOfficialAccountState(AgentOfficialAccountStatus.LoggedOut)
                 null -> AgentOfficialAccountState(
                     status = AgentOfficialAccountStatus.Failed,
-                    message = result.output.takeLast(MAX_MESSAGE_LENGTH).ifBlank { "无法确认登录状态" },
+                    message = "无法确认登录状态",
                 )
             }
         }
@@ -98,7 +232,7 @@ class AgentOfficialAccountManager(
             } else {
                 AgentOfficialAccountState(
                     AgentOfficialAccountStatus.Failed,
-                    result.output.takeLast(MAX_MESSAGE_LENGTH).ifBlank { "登录未完成" },
+                    "登录未完成",
                 )
             }
         }
@@ -114,7 +248,7 @@ class AgentOfficialAccountManager(
             } else {
                 AgentOfficialAccountState(
                     AgentOfficialAccountStatus.Failed,
-                    result.output.takeLast(MAX_MESSAGE_LENGTH).ifBlank { "退出未完成" },
+                    "退出未完成",
                 )
             }
         }
@@ -157,7 +291,7 @@ class AgentOfficialAccountManager(
                         key,
                         AgentOfficialAccountState(
                             AgentOfficialAccountStatus.Failed,
-                            error.message?.take(MAX_MESSAGE_LENGTH) ?: "官方账号操作失败",
+                            "官方账号操作失败",
                         ),
                     )
                 } finally {
@@ -176,11 +310,162 @@ class AgentOfficialAccountManager(
         mutableStates.update { current -> current + (key to state) }
     }
 
+    private suspend fun saveCurrentAccount(
+        agentId: String,
+        loginAccount: AgentOfficialAccountSpec,
+    ): AgentOfficialAccountOperationResult {
+        val vault = vault ?: return AgentOfficialAccountOperationResult.Unsupported("当前版本未启用账号安全存储")
+        val adapter = accountAdapter(agentId)
+            ?: return AgentOfficialAccountOperationResult.Unsupported("当前 Agent 未声明官方账号保存能力")
+        val capabilities = adapter.accountCapabilities()
+        if (!capabilities.supports(AgentAccountCapability.SaveCurrent) ||
+            !capabilities.supports(AgentAccountCapability.StableId)
+        ) {
+            return AgentOfficialAccountOperationResult.Unsupported("当前 Agent 不支持保存官方账号")
+        }
+        val identity = when (val result = adapter.currentIdentity(agentId)) {
+            is AgentAccountIdentityResult.Ready -> result.identity
+            is AgentAccountIdentityResult.Unavailable ->
+                return AgentOfficialAccountOperationResult.Failed(result.message)
+            is AgentAccountIdentityResult.Failed ->
+                return AgentOfficialAccountOperationResult.Failed(result.message)
+        }
+        val credential = when (val result = adapter.captureCurrent(agentId)) {
+            is AgentAccountCredentialReadResult.Ready -> result.snapshot
+            is AgentAccountCredentialReadResult.Missing ->
+                return AgentOfficialAccountOperationResult.Failed(result.message)
+            is AgentAccountCredentialReadResult.Unavailable ->
+                return AgentOfficialAccountOperationResult.Failed(result.message)
+            is AgentAccountCredentialReadResult.Failed ->
+                return AgentOfficialAccountOperationResult.Failed(result.message)
+        }
+        val existing = savedAccounts(agentId).firstOrNull { it.accountId == identity.accountId }
+            ?: withContext(storageDispatcher) { vault.account(agentId, identity.accountId) }
+        val now = System.currentTimeMillis()
+        val saved = AgentSavedOfficialAccount(
+            agentId = agentId,
+            accountId = identity.accountId,
+            displayName = identity.displayName.ifBlank { loginAccount.displayName },
+            createdAt = existing?.createdAt ?: now,
+            lastUsedAt = now,
+        )
+        withContext(storageDispatcher) {
+            vault.save(saved, credential)
+            vault.markCurrent(agentId, identity.accountId)
+        }
+        updateSavedCache(agentId)
+        return AgentOfficialAccountOperationResult.Saved(saved)
+    }
+
+    private suspend fun switchSavedAccount(
+        agentId: String,
+        targetAccountId: String,
+    ): AgentOfficialAccountOperationResult {
+        val vault = vault ?: return AgentOfficialAccountOperationResult.Unsupported("当前版本未启用账号安全存储")
+        val adapter = accountAdapter(agentId)
+            ?: return AgentOfficialAccountOperationResult.Unsupported("当前 Agent 未声明官方账号切换能力")
+        val capabilities = adapter.accountCapabilities()
+        if (!capabilities.supports(AgentAccountCapability.Switch) ||
+            !capabilities.supports(AgentAccountCapability.StableId)
+        ) {
+            return AgentOfficialAccountOperationResult.Unsupported("当前 Agent 不支持切换官方账号")
+        }
+        val target = withContext(storageDispatcher) { vault.account(agentId, targetAccountId) }
+            ?: return AgentOfficialAccountOperationResult.Failed("目标账号档案不存在")
+        val targetCredential = withContext(storageDispatcher) {
+            vault.credential(agentId, targetAccountId)
+        } ?: return AgentOfficialAccountOperationResult.Failed("目标账号凭据不可用")
+        val before = when (val result = adapter.captureCurrent(agentId)) {
+            is AgentAccountCredentialReadResult.Ready -> result.snapshot
+            is AgentAccountCredentialReadResult.Missing ->
+                return AgentOfficialAccountOperationResult.Failed("切换前无法取得当前凭据，已停止切换")
+            is AgentAccountCredentialReadResult.Unavailable ->
+                return AgentOfficialAccountOperationResult.Failed(result.message)
+            is AgentAccountCredentialReadResult.Failed ->
+                return AgentOfficialAccountOperationResult.Failed(result.message)
+        }
+        var nativeChanged = false
+        return try {
+            when (val written = adapter.restoreCurrent(agentId, targetCredential)) {
+                AgentAccountCredentialWriteResult.Applied -> nativeChanged = true
+                is AgentAccountCredentialWriteResult.Unavailable ->
+                    return AgentOfficialAccountOperationResult.Failed(written.message)
+                is AgentAccountCredentialWriteResult.Failed ->
+                    return AgentOfficialAccountOperationResult.Failed(written.message, written.restored)
+            }
+            val verified = when (val identity = adapter.currentIdentity(agentId)) {
+                is AgentAccountIdentityResult.Ready -> identity.identity
+                is AgentAccountIdentityResult.Unavailable -> error(identity.message)
+                is AgentAccountIdentityResult.Failed -> error(identity.message)
+            }
+            if (verified.accountId != targetAccountId) {
+                error("官方状态检查未确认目标账号")
+            }
+            withContext(storageDispatcher) { vault.markCurrent(agentId, targetAccountId) }
+            updateSavedCache(agentId)
+            AgentOfficialAccountOperationResult.Switched(target)
+        } catch (error: CancellationException) {
+            if (nativeChanged) {
+                withContext(NonCancellable) {
+                    runCatching { adapter.restoreCurrent(agentId, before) }
+                }
+            }
+            throw error
+        } catch (_: Throwable) {
+            val restored = if (nativeChanged) {
+                runCatching { adapter.restoreCurrent(agentId, before) }
+                    .getOrNull() is AgentAccountCredentialWriteResult.Applied
+            } else {
+                true
+            }
+            AgentOfficialAccountOperationResult.Failed(
+                message = if (restored) "账号切换验证失败" else "账号切换失败",
+                restored = restored,
+            )
+        }
+    }
+
+    private suspend fun deleteSavedAccount(
+        agentId: String,
+        targetAccountId: String,
+    ): AgentOfficialAccountOperationResult {
+        val vault = vault ?: return AgentOfficialAccountOperationResult.Unsupported("当前版本未启用账号安全存储")
+        val adapter = accountAdapter(agentId)
+            ?: return AgentOfficialAccountOperationResult.Unsupported("当前 Agent 未声明官方账号删除能力")
+        val current = withContext(storageDispatcher) { vault.currentAccountId(agentId) }
+        if (current == targetAccountId) {
+            return AgentOfficialAccountOperationResult.Failed("当前账号不能直接删除，请先切换到其他账号")
+        }
+        val capabilities = adapter.accountCapabilities()
+        if (!capabilities.supports(AgentAccountCapability.Delete) ||
+            !capabilities.supports(AgentAccountCapability.StableId)
+        ) {
+            return AgentOfficialAccountOperationResult.Unsupported("当前 Agent 未声明账号档案管理能力")
+        }
+        val existing = withContext(storageDispatcher) { vault.account(agentId, targetAccountId) }
+            ?: return AgentOfficialAccountOperationResult.Failed("账号档案不存在")
+        withContext(storageDispatcher) { vault.remove(existing.agentId, existing.accountId) }
+        updateSavedCache(agentId)
+        return AgentOfficialAccountOperationResult.Deleted
+    }
+
+    private fun updateSavedCache(agentId: String) {
+        val vault = vault ?: return
+        scope.launch {
+            val accounts = withContext(storageDispatcher) { vault.accounts(agentId) }
+            val currentId = withContext(storageDispatcher) { vault.currentAccountId(agentId) }
+            mutableSavedAccounts.update { current -> current + (agentId to accounts) }
+            mutableCurrentAccountIds.update { current -> current + (agentId to currentId) }
+        }
+    }
+
+    private fun accountAdapter(agentId: String): AgentOfficialAccountAdapter? =
+        accountAdapterResolver?.invoke(agentId)
+
     private fun account(agentId: String, accountId: String): AgentOfficialAccountSpec? =
         accounts(agentId).firstOrNull { it.id == accountId }
 
     private companion object {
-        const val MAX_MESSAGE_LENGTH = 240
     }
 }
 

--- a/app/src/main/java/com/kite/app/agent/auth/AgentOfficialAccountManager.kt
+++ b/app/src/main/java/com/kite/app/agent/auth/AgentOfficialAccountManager.kt
@@ -468,6 +468,16 @@ internal class AgentOfficialAccountManager(
         ) {
             return AgentOfficialAccountOperationResult.Unsupported("当前 Agent 未声明账号档案管理能力")
         }
+        val actualCurrent = when (val identity = adapter.currentIdentity(agentId)) {
+            is AgentAccountIdentityResult.Ready -> identity.identity.accountId
+            is AgentAccountIdentityResult.Unavailable,
+            is AgentAccountIdentityResult.Failed -> null
+        }
+        if (actualCurrent == targetAccountId) {
+            withContext(storageDispatcher) { vault.markCurrent(agentId, targetAccountId) }
+            updateSavedCache(agentId)
+            return AgentOfficialAccountOperationResult.Failed("当前账号不能直接删除，请先切换到其他账号")
+        }
         val existing = withContext(storageDispatcher) { vault.account(agentId, targetAccountId) }
             ?: return AgentOfficialAccountOperationResult.Failed("账号档案不存在")
         withContext(storageDispatcher) { vault.remove(existing.agentId, existing.accountId) }

--- a/app/src/main/java/com/kite/app/agent/auth/AgentOfficialAccountVault.kt
+++ b/app/src/main/java/com/kite/app/agent/auth/AgentOfficialAccountVault.kt
@@ -132,7 +132,7 @@ internal class AndroidAgentOfficialAccountVault(context: Context) : AgentOfficia
             if (updated == 0) {
                 insertOrThrow(TABLE_ACCOUNTS, null, metadata)
             }
-            insertWithOnConflict(
+            val credentialRow = insertWithOnConflict(
                 TABLE_CREDENTIALS,
                 null,
                 ContentValues().apply {
@@ -142,6 +142,7 @@ internal class AndroidAgentOfficialAccountVault(context: Context) : AgentOfficia
                 },
                 SQLiteDatabase.CONFLICT_REPLACE,
             )
+            check(credentialRow != -1L) { "无法保存账号加密凭据" }
         }
     }
 
@@ -163,7 +164,7 @@ internal class AndroidAgentOfficialAccountVault(context: Context) : AgentOfficia
 
     override fun markCurrent(agentId: String, accountId: String) {
         database.writableDatabase.runInTransaction {
-            insertWithOnConflict(
+            val currentRow = insertWithOnConflict(
                 TABLE_CURRENT,
                 null,
                 ContentValues().apply {
@@ -172,6 +173,7 @@ internal class AndroidAgentOfficialAccountVault(context: Context) : AgentOfficia
                 },
                 SQLiteDatabase.CONFLICT_REPLACE,
             )
+            check(currentRow != -1L) { "无法更新当前账号档案" }
             execSQL(
                 "UPDATE $TABLE_ACCOUNTS SET $COL_LAST_USED_AT = ? WHERE $COL_AGENT_ID = ? AND $COL_ACCOUNT_ID = ?",
                 arrayOf<Any?>(System.currentTimeMillis(), agentId, accountId),

--- a/app/src/main/java/com/kite/app/agent/auth/AgentOfficialAccountVault.kt
+++ b/app/src/main/java/com/kite/app/agent/auth/AgentOfficialAccountVault.kt
@@ -1,0 +1,319 @@
+package com.kite.app.agent.auth
+
+import android.content.ContentValues
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteOpenHelper
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import com.kite.app.agent.sdk.account.AgentAccountCredentialSnapshot
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+internal data class AgentSavedOfficialAccount(
+    val agentId: String,
+    val accountId: String,
+    val displayName: String,
+    val createdAt: Long,
+    val lastUsedAt: Long,
+)
+
+/** 账号元数据和加密原生凭据分开保存；页面只消费元数据。 */
+internal interface AgentOfficialAccountVault {
+    fun accounts(agentId: String): List<AgentSavedOfficialAccount>
+
+    fun account(agentId: String, accountId: String): AgentSavedOfficialAccount?
+
+    fun currentAccountId(agentId: String): String?
+
+    fun save(
+        account: AgentSavedOfficialAccount,
+        credential: AgentAccountCredentialSnapshot,
+    )
+
+    fun credential(agentId: String, accountId: String): AgentAccountCredentialSnapshot?
+
+    fun markCurrent(agentId: String, accountId: String)
+
+    fun remove(agentId: String, accountId: String)
+}
+
+/**
+ * Android 私有 SQLite + Android Keystore 账号档案。
+ *
+ * 数据库中只保存 AES-GCM 密文；Keystore 主密钥不离开系统 Keystore。任何加密/解密失败都
+ * 直接报错，不降级为明文存储。
+ */
+internal class AndroidAgentOfficialAccountVault(context: Context) : AgentOfficialAccountVault {
+    private val database = AccountDatabase(context.applicationContext)
+
+    override fun accounts(agentId: String): List<AgentSavedOfficialAccount> =
+        database.readableDatabase.query(
+            TABLE_ACCOUNTS,
+            arrayOf(COL_AGENT_ID, COL_ACCOUNT_ID, COL_DISPLAY_NAME, COL_CREATED_AT, COL_LAST_USED_AT),
+            "$COL_AGENT_ID = ?",
+            arrayOf(agentId),
+            null,
+            null,
+            "$COL_LAST_USED_AT DESC, $COL_CREATED_AT ASC, $COL_ACCOUNT_ID ASC",
+        ).use { cursor ->
+            buildList {
+                while (cursor.moveToNext()) {
+                    add(
+                        AgentSavedOfficialAccount(
+                            agentId = cursor.getString(0),
+                            accountId = cursor.getString(1),
+                            displayName = cursor.getString(2),
+                            createdAt = cursor.getLong(3),
+                            lastUsedAt = cursor.getLong(4),
+                        )
+                    )
+                }
+            }
+        }
+
+    override fun account(agentId: String, accountId: String): AgentSavedOfficialAccount? =
+        database.readableDatabase.query(
+            TABLE_ACCOUNTS,
+            arrayOf(COL_AGENT_ID, COL_ACCOUNT_ID, COL_DISPLAY_NAME, COL_CREATED_AT, COL_LAST_USED_AT),
+            "$COL_AGENT_ID = ? AND $COL_ACCOUNT_ID = ?",
+            arrayOf(agentId, accountId),
+            null,
+            null,
+            null,
+            "1",
+        ).use { cursor ->
+            if (!cursor.moveToFirst()) return@use null
+            AgentSavedOfficialAccount(
+                agentId = cursor.getString(0),
+                accountId = cursor.getString(1),
+                displayName = cursor.getString(2),
+                createdAt = cursor.getLong(3),
+                lastUsedAt = cursor.getLong(4),
+            )
+        }
+
+    override fun currentAccountId(agentId: String): String? =
+        database.readableDatabase.query(
+            TABLE_CURRENT,
+            arrayOf(COL_ACCOUNT_ID),
+            "$COL_AGENT_ID = ?",
+            arrayOf(agentId),
+            null,
+            null,
+            null,
+            "1",
+        ).use { cursor ->
+            if (cursor.moveToFirst()) cursor.getString(0) else null
+        }
+
+    override fun save(
+        account: AgentSavedOfficialAccount,
+        credential: AgentAccountCredentialSnapshot,
+    ) {
+        val encrypted = encrypt(storageKey(account.agentId, account.accountId), credential.bytes)
+        database.writableDatabase.runInTransaction {
+            val metadata = ContentValues().apply {
+                put(COL_AGENT_ID, account.agentId)
+                put(COL_ACCOUNT_ID, account.accountId)
+                put(COL_DISPLAY_NAME, account.displayName)
+                put(COL_CREATED_AT, account.createdAt)
+                put(COL_LAST_USED_AT, account.lastUsedAt)
+            }
+            val updated = update(
+                TABLE_ACCOUNTS,
+                metadata,
+                "$COL_AGENT_ID = ? AND $COL_ACCOUNT_ID = ?",
+                arrayOf(account.agentId, account.accountId),
+            )
+            if (updated == 0) {
+                insertOrThrow(TABLE_ACCOUNTS, null, metadata)
+            }
+            insertWithOnConflict(
+                TABLE_CREDENTIALS,
+                null,
+                ContentValues().apply {
+                    put(COL_AGENT_ID, account.agentId)
+                    put(COL_ACCOUNT_ID, account.accountId)
+                    put(COL_CIPHERTEXT, encrypted)
+                },
+                SQLiteDatabase.CONFLICT_REPLACE,
+            )
+        }
+    }
+
+    override fun credential(agentId: String, accountId: String): AgentAccountCredentialSnapshot? =
+        database.readableDatabase.query(
+            TABLE_CREDENTIALS,
+            arrayOf(COL_CIPHERTEXT),
+            "$COL_AGENT_ID = ? AND $COL_ACCOUNT_ID = ?",
+            arrayOf(agentId, accountId),
+            null,
+            null,
+            null,
+            "1",
+        ).use { cursor ->
+            if (!cursor.moveToFirst()) return@use null
+            val encrypted = cursor.getBlob(0)
+            AgentAccountCredentialSnapshot(decrypt(storageKey(agentId, accountId), encrypted))
+        }
+
+    override fun markCurrent(agentId: String, accountId: String) {
+        database.writableDatabase.runInTransaction {
+            insertWithOnConflict(
+                TABLE_CURRENT,
+                null,
+                ContentValues().apply {
+                    put(COL_AGENT_ID, agentId)
+                    put(COL_ACCOUNT_ID, accountId)
+                },
+                SQLiteDatabase.CONFLICT_REPLACE,
+            )
+            execSQL(
+                "UPDATE $TABLE_ACCOUNTS SET $COL_LAST_USED_AT = ? WHERE $COL_AGENT_ID = ? AND $COL_ACCOUNT_ID = ?",
+                arrayOf<Any?>(System.currentTimeMillis(), agentId, accountId),
+            )
+        }
+    }
+
+    override fun remove(agentId: String, accountId: String) {
+        database.writableDatabase.delete(
+            TABLE_ACCOUNTS,
+            "$COL_AGENT_ID = ? AND $COL_ACCOUNT_ID = ?",
+            arrayOf(agentId, accountId),
+        )
+    }
+
+    private fun encrypt(aadKey: String, bytes: ByteArray): ByteArray {
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey())
+        cipher.updateAAD(aadKey.toByteArray(Charsets.UTF_8))
+        val ciphertext = cipher.doFinal(bytes)
+        return ByteArray(cipher.iv.size + ciphertext.size).also { payload ->
+            cipher.iv.copyInto(payload)
+            ciphertext.copyInto(payload, cipher.iv.size)
+        }
+    }
+
+    private fun decrypt(aadKey: String, payload: ByteArray): ByteArray {
+        require(payload.size > IV_BYTES) { "账号凭据密文无效" }
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(
+            Cipher.DECRYPT_MODE,
+            secretKey(),
+            GCMParameterSpec(TAG_BITS, payload, 0, IV_BYTES),
+        )
+        cipher.updateAAD(aadKey.toByteArray(Charsets.UTF_8))
+        return cipher.doFinal(payload.copyOfRange(IV_BYTES, payload.size))
+    }
+
+    private fun secretKey(): SecretKey {
+        val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+        (keyStore.getKey(KEY_ALIAS, null) as? SecretKey)?.let { return it }
+        val generator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE)
+        generator.init(
+            KeyGenParameterSpec.Builder(
+                KEY_ALIAS,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+            ).setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .setRandomizedEncryptionRequired(true)
+                .build(),
+        )
+        return generator.generateKey()
+    }
+
+    private fun storageKey(agentId: String, accountId: String): String =
+        "$agentId\u0000$accountId"
+
+    private class AccountDatabase(context: Context) :
+        SQLiteOpenHelper(context, DATABASE_NAME, null, DATABASE_VERSION) {
+
+        init {
+            setWriteAheadLoggingEnabled(true)
+        }
+
+        override fun onConfigure(db: SQLiteDatabase) {
+            db.setForeignKeyConstraintsEnabled(true)
+        }
+
+        override fun onCreate(db: SQLiteDatabase) {
+            createSchema(db)
+        }
+
+        override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
+            createSchema(db)
+        }
+
+        private fun createSchema(db: SQLiteDatabase) {
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS $TABLE_ACCOUNTS (
+                    $COL_AGENT_ID TEXT NOT NULL,
+                    $COL_ACCOUNT_ID TEXT NOT NULL,
+                    $COL_DISPLAY_NAME TEXT NOT NULL,
+                    $COL_CREATED_AT INTEGER NOT NULL,
+                    $COL_LAST_USED_AT INTEGER NOT NULL,
+                    PRIMARY KEY($COL_AGENT_ID, $COL_ACCOUNT_ID)
+                )
+                """.trimIndent()
+            )
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS $TABLE_CREDENTIALS (
+                    $COL_AGENT_ID TEXT NOT NULL,
+                    $COL_ACCOUNT_ID TEXT NOT NULL,
+                    $COL_CIPHERTEXT BLOB NOT NULL,
+                    PRIMARY KEY($COL_AGENT_ID, $COL_ACCOUNT_ID),
+                    FOREIGN KEY($COL_AGENT_ID, $COL_ACCOUNT_ID)
+                        REFERENCES $TABLE_ACCOUNTS($COL_AGENT_ID, $COL_ACCOUNT_ID)
+                        ON DELETE CASCADE
+                )
+                """.trimIndent()
+            )
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS $TABLE_CURRENT (
+                    $COL_AGENT_ID TEXT PRIMARY KEY NOT NULL,
+                    $COL_ACCOUNT_ID TEXT NOT NULL,
+                    FOREIGN KEY($COL_AGENT_ID, $COL_ACCOUNT_ID)
+                        REFERENCES $TABLE_ACCOUNTS($COL_AGENT_ID, $COL_ACCOUNT_ID)
+                        ON DELETE CASCADE
+                )
+                """.trimIndent()
+            )
+        }
+    }
+
+    private fun SQLiteDatabase.runInTransaction(block: SQLiteDatabase.() -> Unit) {
+        beginTransaction()
+        try {
+            block()
+            setTransactionSuccessful()
+        } finally {
+            endTransaction()
+        }
+    }
+
+    private companion object {
+        const val DATABASE_NAME = "kite_agent_accounts.db"
+        const val DATABASE_VERSION = 1
+        const val TABLE_ACCOUNTS = "agent_account_metadata"
+        const val TABLE_CREDENTIALS = "agent_account_credentials"
+        const val TABLE_CURRENT = "agent_account_current"
+        const val COL_AGENT_ID = "agent_id"
+        const val COL_ACCOUNT_ID = "account_id"
+        const val COL_DISPLAY_NAME = "display_name"
+        const val COL_CREATED_AT = "created_at"
+        const val COL_LAST_USED_AT = "last_used_at"
+        const val COL_CIPHERTEXT = "ciphertext"
+        const val ANDROID_KEYSTORE = "AndroidKeyStore"
+        const val KEY_ALIAS = "kite.agent.accounts.v1"
+        const val TRANSFORMATION = "AES/GCM/NoPadding"
+        const val IV_BYTES = 12
+        const val TAG_BITS = 128
+    }
+}

--- a/app/src/main/java/com/kite/app/agent/config/AgentAccountAdapterContract.kt
+++ b/app/src/main/java/com/kite/app/agent/config/AgentAccountAdapterContract.kt
@@ -1,0 +1,8 @@
+package com.kite.app.agent.config
+
+import com.kite.app.agent.sdk.account.AgentOfficialAccountAdapter
+
+/** 只有具体原生配置 Adapter 才能声明官方账号凭据能力。 */
+internal interface AgentOfficialAccountAdapterProvider {
+    fun officialAccountAdapter(): AgentOfficialAccountAdapter?
+}

--- a/app/src/main/java/com/kite/app/agent/config/AgentConfigAdapterRegistry.kt
+++ b/app/src/main/java/com/kite/app/agent/config/AgentConfigAdapterRegistry.kt
@@ -19,6 +19,13 @@ class AgentConfigAdapterRegistry(adapters: List<AgentConfigAdapter>) {
     fun adapterFor(registration: AgentRegistration): AgentConfigAdapter? =
         adapter(registration.configAdapterId)
 
+    /** 账号能力只从具体 Adapter 获取，页面不按 Agent 名称猜测原生凭据位置。 */
+    internal fun officialAccountAdapterFor(registration: AgentRegistration): com.kite.app.agent.sdk.account.AgentOfficialAccountAdapter? =
+        adapterFor(registration)
+            ?.let { adapter ->
+                (adapter as? AgentOfficialAccountAdapterProvider)?.officialAccountAdapter()
+            }
+
     fun adapterIds(): Set<String> = adaptersById.keys
 
     private companion object {

--- a/app/src/main/java/com/kite/app/agent/config/native/codex/CodexAgentConfigAdapter.kt
+++ b/app/src/main/java/com/kite/app/agent/config/native/codex/CodexAgentConfigAdapter.kt
@@ -94,10 +94,7 @@ internal class CodexAgentConfigAdapter(
             ?: return@runCatching AgentAccountIdentityResult.Unavailable("Codex 官方登录尚未生成原生凭据")
         val accountId = codexAccountId(bytes)
             ?: return@runCatching AgentAccountIdentityResult.Unavailable("Codex 没有提供稳定账号 ID")
-        AgentAccountIdentity(
-            accountId = accountId,
-            displayName = "ChatGPT · ${compactAccountId(accountId)}",
-        ).let(AgentAccountIdentityResult::Ready)
+        codexIdentity(accountId).let(AgentAccountIdentityResult::Ready)
     }.getOrElse { error ->
         AgentAccountIdentityResult.Failed(error.message ?: "无法读取 Codex 官方账号状态")
     }
@@ -105,10 +102,12 @@ internal class CodexAgentConfigAdapter(
     override suspend fun captureCurrent(agentId: String): AgentAccountCredentialReadResult = runCatching {
         val bytes = readAuthBytes()
             ?: return@runCatching AgentAccountCredentialReadResult.Missing()
-        if (codexAccountId(bytes) == null) {
-            return@runCatching AgentAccountCredentialReadResult.Unavailable("Codex 凭据缺少稳定账号 ID")
-        }
-        AgentAccountCredentialReadResult.Ready(AgentAccountCredentialSnapshot(bytes.copyOf()))
+        val accountId = codexAccountId(bytes)
+            ?: return@runCatching AgentAccountCredentialReadResult.Unavailable("Codex 凭据缺少稳定账号 ID")
+        AgentAccountCredentialReadResult.Ready(
+            snapshot = AgentAccountCredentialSnapshot(bytes.copyOf()),
+            identity = codexIdentity(accountId),
+        )
     }.getOrElse { error ->
         AgentAccountCredentialReadResult.Failed(error.message ?: "无法读取 Codex 官方凭据")
     }
@@ -601,6 +600,11 @@ internal class CodexAgentConfigAdapter(
 
     private fun compactAccountId(accountId: String): String =
         if (accountId.length <= 12) accountId else "${accountId.take(6)}…${accountId.takeLast(4)}"
+
+    private fun codexIdentity(accountId: String): AgentAccountIdentity = AgentAccountIdentity(
+        accountId = accountId,
+        displayName = "ChatGPT · ${compactAccountId(accountId)}",
+    )
 
     private fun codexSkillActivation(parsed: org.tomlj.TomlParseResult, path: String): AgentSkillActivation {
         val overrides = parsed.getArray("skills.config") ?: return AgentSkillActivation.Enabled

--- a/app/src/main/java/com/kite/app/agent/config/native/codex/CodexAgentConfigAdapter.kt
+++ b/app/src/main/java/com/kite/app/agent/config/native/codex/CodexAgentConfigAdapter.kt
@@ -6,6 +6,7 @@ import com.kite.app.agent.config.AgentConfigApplyResult
 import com.kite.app.agent.config.AgentConfigCapabilities
 import com.kite.app.agent.config.AgentConfigReadResult
 import com.kite.app.agent.config.AgentConfigValidationProblem
+import com.kite.app.agent.config.AgentOfficialAccountAdapterProvider
 import com.kite.app.agent.config.AgentCredentialOwnership
 import com.kite.app.agent.config.AgentCredentialPresence
 import com.kite.app.agent.config.AgentLiveConfigSnapshot
@@ -37,8 +38,17 @@ import com.kite.app.agent.codex.codexPermissionOption
 import com.kite.app.agent.contract.AgentConfigCategory
 import com.kite.app.agent.contract.AgentConfigOption
 import com.kite.app.agent.contract.AgentModelSource
+import com.kite.app.agent.sdk.account.AgentAccountCapabilities
+import com.kite.app.agent.sdk.account.AgentAccountCapability
+import com.kite.app.agent.sdk.account.AgentAccountCredentialReadResult
+import com.kite.app.agent.sdk.account.AgentAccountCredentialSnapshot
+import com.kite.app.agent.sdk.account.AgentAccountCredentialWriteResult
+import com.kite.app.agent.sdk.account.AgentAccountIdentity
+import com.kite.app.agent.sdk.account.AgentAccountIdentityResult
+import com.kite.app.agent.sdk.account.AgentOfficialAccountAdapter
 import com.kite.app.foundation.contracts.ContainerRecord
 import com.kite.app.foundation.workspace.WorkSurfaceRuntimeBridge
+import org.json.JSONObject
 import org.tomlj.Toml
 import java.net.URI
 
@@ -59,7 +69,7 @@ internal class CodexAgentConfigAdapter(
     CONFIG_KEY,
     containerProvider,
     fileStore
-) {
+), AgentOfficialAccountAdapterProvider, AgentOfficialAccountAdapter {
     private val skillDirectory = NativeAgentSkillDirectory(
         project = projection::resolve,
         roots = listOf(CODEX_SKILL_ROOT, AGENTS_SKILL_ROOT),
@@ -67,6 +77,72 @@ internal class CodexAgentConfigAdapter(
     )
 
     override fun displayName(): String = "Codex"
+
+    override fun officialAccountAdapter(): AgentOfficialAccountAdapter = this
+
+    override fun accountCapabilities(): AgentAccountCapabilities = AgentAccountCapabilities(
+        supported = setOf(
+            AgentAccountCapability.SaveCurrent,
+            AgentAccountCapability.Switch,
+            AgentAccountCapability.Delete,
+            AgentAccountCapability.StableId,
+        ),
+    )
+
+    override suspend fun currentIdentity(agentId: String): AgentAccountIdentityResult = runCatching {
+        val bytes = readAuthBytes()
+            ?: return@runCatching AgentAccountIdentityResult.Unavailable("Codex 官方登录尚未生成原生凭据")
+        val accountId = codexAccountId(bytes)
+            ?: return@runCatching AgentAccountIdentityResult.Unavailable("Codex 没有提供稳定账号 ID")
+        AgentAccountIdentity(
+            accountId = accountId,
+            displayName = "ChatGPT · ${compactAccountId(accountId)}",
+        ).let(AgentAccountIdentityResult::Ready)
+    }.getOrElse { error ->
+        AgentAccountIdentityResult.Failed(error.message ?: "无法读取 Codex 官方账号状态")
+    }
+
+    override suspend fun captureCurrent(agentId: String): AgentAccountCredentialReadResult = runCatching {
+        val bytes = readAuthBytes()
+            ?: return@runCatching AgentAccountCredentialReadResult.Missing()
+        if (codexAccountId(bytes) == null) {
+            return@runCatching AgentAccountCredentialReadResult.Unavailable("Codex 凭据缺少稳定账号 ID")
+        }
+        AgentAccountCredentialReadResult.Ready(AgentAccountCredentialSnapshot(bytes.copyOf()))
+    }.getOrElse { error ->
+        AgentAccountCredentialReadResult.Failed(error.message ?: "无法读取 Codex 官方凭据")
+    }
+
+    override suspend fun restoreCurrent(
+        agentId: String,
+        snapshot: AgentAccountCredentialSnapshot,
+    ): AgentAccountCredentialWriteResult {
+        val target = projection.resolve(AUTH_PATH)?.writeFile
+            ?: return AgentAccountCredentialWriteResult.Unavailable("Kite 运行容器尚未创建")
+        val before = runCatching { fileStore.read(target) }.getOrElse { error ->
+            return AgentAccountCredentialWriteResult.Failed(
+                error.message ?: "无法读取 Codex 原生凭据",
+                restored = false,
+            )
+        }
+        return when (
+            val result = fileStore.replace(
+                target = target,
+                expectedRevision = before.revision,
+                nextBytes = snapshot.bytes.copyOf(),
+                validate = ::validateAuthBytes,
+            )
+        ) {
+            is com.kite.app.agent.config.AtomicConfigFileWriteResult.Applied ->
+                AgentAccountCredentialWriteResult.Applied
+            is com.kite.app.agent.config.AtomicConfigFileWriteResult.Conflict ->
+                AgentAccountCredentialWriteResult.Failed("Codex 原生凭据在切换期间发生变化", restored = false)
+            is com.kite.app.agent.config.AtomicConfigFileWriteResult.Rejected ->
+                AgentAccountCredentialWriteResult.Failed(result.message, restored = false)
+            is com.kite.app.agent.config.AtomicConfigFileWriteResult.Failed ->
+                AgentAccountCredentialWriteResult.Failed(result.message, result.restored)
+        }
+    }
 
     override fun reasoningControl(): AgentReasoningControl = codexReasoningControl
 
@@ -495,6 +571,37 @@ internal class CodexAgentConfigAdapter(
         ?.trim()
         .orEmpty()
 
+    private fun readAuthBytes(): ByteArray? = projection.resolve(AUTH_PATH)
+        ?.readFile
+        ?.let(fileStore::read)
+        ?.bytes
+        ?.takeIf { it.isNotEmpty() }
+
+    private fun codexAccountId(bytes: ByteArray): String? = runCatching {
+        val root = JSONObject(bytes.toString(Charsets.UTF_8))
+        val tokens = root.optJSONObject("tokens")
+        listOf(
+            root.optString("account_id"),
+            root.optString("accountId"),
+            tokens?.optString("account_id").orEmpty(),
+            tokens?.optString("accountId").orEmpty(),
+            tokens?.optString("chatgpt_account_id").orEmpty(),
+        ).firstOrNull { value ->
+            value.isNotBlank() && value.length <= MAX_ACCOUNT_ID && value.none(Char::isISOControl)
+        }
+    }.getOrNull()
+
+    private fun validateAuthBytes(bytes: ByteArray): String? = runCatching {
+        require(bytes.isNotEmpty()) { "Codex 官方凭据不能为空" }
+        val root = JSONObject(bytes.toString(Charsets.UTF_8))
+        require(root.optJSONObject("tokens") != null) { "Codex 官方凭据格式无效" }
+        require(codexAccountId(bytes) != null) { "Codex 官方凭据缺少稳定账号 ID" }
+        null
+    }.getOrElse { error -> error.message ?: "Codex 官方凭据格式无效" }
+
+    private fun compactAccountId(accountId: String): String =
+        if (accountId.length <= 12) accountId else "${accountId.take(6)}…${accountId.takeLast(4)}"
+
     private fun codexSkillActivation(parsed: org.tomlj.TomlParseResult, path: String): AgentSkillActivation {
         val overrides = parsed.getArray("skills.config") ?: return AgentSkillActivation.Enabled
         repeat(overrides.size()) { index ->
@@ -555,6 +662,7 @@ internal class CodexAgentConfigAdapter(
         const val ADAPTER_ID = "codex"
         private const val CONFIG_KEY = "config"
         private const val CONFIG_PATH = "/root/.codex/config.toml"
+        private const val AUTH_PATH = "/root/.codex/auth.json"
         private const val RELAY_UPSTREAM_KEY = "relay-upstream"
         private const val RELAY_UPSTREAM_PATH = "/workspace/.kf/secrets/kite.codex-relay-upstream"
         private const val RELAY_API_KEY_KEY = "relay-api-key"
@@ -570,6 +678,7 @@ internal class CodexAgentConfigAdapter(
         private const val MAX_MCP_TEXT = 2_048
         private const val MAX_RELAY_UPSTREAM_BYTES = 4 * 1024
         private const val MAX_RELAY_API_KEY_BYTES = 64 * 1024
+        private const val MAX_ACCOUNT_ID = 256
         private val CODEX_PERMISSION_LEVELS = mapOf(
             "read-only" to AgentPermissionLevel.ReadOnly,
             "agent" to AgentPermissionLevel.Approval,

--- a/app/src/main/java/com/kite/app/agent/config/native/codex/CodexAgentConfigAdapter.kt
+++ b/app/src/main/java/com/kite/app/agent/config/native/codex/CodexAgentConfigAdapter.kt
@@ -38,17 +38,8 @@ import com.kite.app.agent.codex.codexPermissionOption
 import com.kite.app.agent.contract.AgentConfigCategory
 import com.kite.app.agent.contract.AgentConfigOption
 import com.kite.app.agent.contract.AgentModelSource
-import com.kite.app.agent.sdk.account.AgentAccountCapabilities
-import com.kite.app.agent.sdk.account.AgentAccountCapability
-import com.kite.app.agent.sdk.account.AgentAccountCredentialReadResult
-import com.kite.app.agent.sdk.account.AgentAccountCredentialSnapshot
-import com.kite.app.agent.sdk.account.AgentAccountCredentialWriteResult
-import com.kite.app.agent.sdk.account.AgentAccountIdentity
-import com.kite.app.agent.sdk.account.AgentAccountIdentityResult
-import com.kite.app.agent.sdk.account.AgentOfficialAccountAdapter
 import com.kite.app.foundation.contracts.ContainerRecord
 import com.kite.app.foundation.workspace.WorkSurfaceRuntimeBridge
-import org.json.JSONObject
 import org.tomlj.Toml
 import java.net.URI
 
@@ -69,79 +60,17 @@ internal class CodexAgentConfigAdapter(
     CONFIG_KEY,
     containerProvider,
     fileStore
-), AgentOfficialAccountAdapterProvider, AgentOfficialAccountAdapter {
+), AgentOfficialAccountAdapterProvider {
     private val skillDirectory = NativeAgentSkillDirectory(
         project = projection::resolve,
         roots = listOf(CODEX_SKILL_ROOT, AGENTS_SKILL_ROOT),
         mutableRoots = setOf(CODEX_SKILL_ROOT, AGENTS_SKILL_ROOT),
     )
+    private val officialAccountAdapter = CodexOfficialAccountAdapter(containerProvider, fileStore)
 
     override fun displayName(): String = "Codex"
 
-    override fun officialAccountAdapter(): AgentOfficialAccountAdapter = this
-
-    override fun accountCapabilities(): AgentAccountCapabilities = AgentAccountCapabilities(
-        supported = setOf(
-            AgentAccountCapability.SaveCurrent,
-            AgentAccountCapability.Switch,
-            AgentAccountCapability.Delete,
-            AgentAccountCapability.StableId,
-        ),
-    )
-
-    override suspend fun currentIdentity(agentId: String): AgentAccountIdentityResult = runCatching {
-        val bytes = readAuthBytes()
-            ?: return@runCatching AgentAccountIdentityResult.Unavailable("Codex 官方登录尚未生成原生凭据")
-        val accountId = codexAccountId(bytes)
-            ?: return@runCatching AgentAccountIdentityResult.Unavailable("Codex 没有提供稳定账号 ID")
-        codexIdentity(accountId).let(AgentAccountIdentityResult::Ready)
-    }.getOrElse { error ->
-        AgentAccountIdentityResult.Failed(error.message ?: "无法读取 Codex 官方账号状态")
-    }
-
-    override suspend fun captureCurrent(agentId: String): AgentAccountCredentialReadResult = runCatching {
-        val bytes = readAuthBytes()
-            ?: return@runCatching AgentAccountCredentialReadResult.Missing()
-        val accountId = codexAccountId(bytes)
-            ?: return@runCatching AgentAccountCredentialReadResult.Unavailable("Codex 凭据缺少稳定账号 ID")
-        AgentAccountCredentialReadResult.Ready(
-            snapshot = AgentAccountCredentialSnapshot(bytes.copyOf()),
-            identity = codexIdentity(accountId),
-        )
-    }.getOrElse { error ->
-        AgentAccountCredentialReadResult.Failed(error.message ?: "无法读取 Codex 官方凭据")
-    }
-
-    override suspend fun restoreCurrent(
-        agentId: String,
-        snapshot: AgentAccountCredentialSnapshot,
-    ): AgentAccountCredentialWriteResult {
-        val target = projection.resolve(AUTH_PATH)?.writeFile
-            ?: return AgentAccountCredentialWriteResult.Unavailable("Kite 运行容器尚未创建")
-        val before = runCatching { fileStore.read(target) }.getOrElse { error ->
-            return AgentAccountCredentialWriteResult.Failed(
-                error.message ?: "无法读取 Codex 原生凭据",
-                restored = false,
-            )
-        }
-        return when (
-            val result = fileStore.replace(
-                target = target,
-                expectedRevision = before.revision,
-                nextBytes = snapshot.bytes.copyOf(),
-                validate = ::validateAuthBytes,
-            )
-        ) {
-            is com.kite.app.agent.config.AtomicConfigFileWriteResult.Applied ->
-                AgentAccountCredentialWriteResult.Applied
-            is com.kite.app.agent.config.AtomicConfigFileWriteResult.Conflict ->
-                AgentAccountCredentialWriteResult.Failed("Codex 原生凭据在切换期间发生变化", restored = false)
-            is com.kite.app.agent.config.AtomicConfigFileWriteResult.Rejected ->
-                AgentAccountCredentialWriteResult.Failed(result.message, restored = false)
-            is com.kite.app.agent.config.AtomicConfigFileWriteResult.Failed ->
-                AgentAccountCredentialWriteResult.Failed(result.message, result.restored)
-        }
-    }
+    override fun officialAccountAdapter() = officialAccountAdapter
 
     override fun reasoningControl(): AgentReasoningControl = codexReasoningControl
 
@@ -570,42 +499,6 @@ internal class CodexAgentConfigAdapter(
         ?.trim()
         .orEmpty()
 
-    private fun readAuthBytes(): ByteArray? = projection.resolve(AUTH_PATH)
-        ?.readFile
-        ?.let(fileStore::read)
-        ?.bytes
-        ?.takeIf { it.isNotEmpty() }
-
-    private fun codexAccountId(bytes: ByteArray): String? = runCatching {
-        val root = JSONObject(bytes.toString(Charsets.UTF_8))
-        val tokens = root.optJSONObject("tokens")
-        listOf(
-            root.optString("account_id"),
-            root.optString("accountId"),
-            tokens?.optString("account_id").orEmpty(),
-            tokens?.optString("accountId").orEmpty(),
-            tokens?.optString("chatgpt_account_id").orEmpty(),
-        ).firstOrNull { value ->
-            value.isNotBlank() && value.length <= MAX_ACCOUNT_ID && value.none(Char::isISOControl)
-        }
-    }.getOrNull()
-
-    private fun validateAuthBytes(bytes: ByteArray): String? = runCatching {
-        require(bytes.isNotEmpty()) { "Codex 官方凭据不能为空" }
-        val root = JSONObject(bytes.toString(Charsets.UTF_8))
-        require(root.optJSONObject("tokens") != null) { "Codex 官方凭据格式无效" }
-        require(codexAccountId(bytes) != null) { "Codex 官方凭据缺少稳定账号 ID" }
-        null
-    }.getOrElse { error -> error.message ?: "Codex 官方凭据格式无效" }
-
-    private fun compactAccountId(accountId: String): String =
-        if (accountId.length <= 12) accountId else "${accountId.take(6)}…${accountId.takeLast(4)}"
-
-    private fun codexIdentity(accountId: String): AgentAccountIdentity = AgentAccountIdentity(
-        accountId = accountId,
-        displayName = "ChatGPT · ${compactAccountId(accountId)}",
-    )
-
     private fun codexSkillActivation(parsed: org.tomlj.TomlParseResult, path: String): AgentSkillActivation {
         val overrides = parsed.getArray("skills.config") ?: return AgentSkillActivation.Enabled
         repeat(overrides.size()) { index ->
@@ -666,7 +559,6 @@ internal class CodexAgentConfigAdapter(
         const val ADAPTER_ID = "codex"
         private const val CONFIG_KEY = "config"
         private const val CONFIG_PATH = "/root/.codex/config.toml"
-        private const val AUTH_PATH = "/root/.codex/auth.json"
         private const val RELAY_UPSTREAM_KEY = "relay-upstream"
         private const val RELAY_UPSTREAM_PATH = "/workspace/.kf/secrets/kite.codex-relay-upstream"
         private const val RELAY_API_KEY_KEY = "relay-api-key"
@@ -682,7 +574,6 @@ internal class CodexAgentConfigAdapter(
         private const val MAX_MCP_TEXT = 2_048
         private const val MAX_RELAY_UPSTREAM_BYTES = 4 * 1024
         private const val MAX_RELAY_API_KEY_BYTES = 64 * 1024
-        private const val MAX_ACCOUNT_ID = 256
         private val CODEX_PERMISSION_LEVELS = mapOf(
             "read-only" to AgentPermissionLevel.ReadOnly,
             "agent" to AgentPermissionLevel.Approval,

--- a/app/src/main/java/com/kite/app/agent/config/native/codex/CodexOfficialAccountAdapter.kt
+++ b/app/src/main/java/com/kite/app/agent/config/native/codex/CodexOfficialAccountAdapter.kt
@@ -1,0 +1,127 @@
+package com.kite.app.agent.config.native
+
+import com.kite.app.agent.config.AtomicConfigFileStore
+import com.kite.app.agent.config.AtomicConfigFileWriteResult
+import com.kite.app.agent.config.ContainerAgentConfigProjection
+import com.kite.app.agent.sdk.account.AgentAccountCapabilities
+import com.kite.app.agent.sdk.account.AgentAccountCapability
+import com.kite.app.agent.sdk.account.AgentAccountCredentialReadResult
+import com.kite.app.agent.sdk.account.AgentAccountCredentialSnapshot
+import com.kite.app.agent.sdk.account.AgentAccountCredentialWriteResult
+import com.kite.app.agent.sdk.account.AgentAccountIdentity
+import com.kite.app.agent.sdk.account.AgentAccountIdentityResult
+import com.kite.app.agent.sdk.account.AgentOfficialAccountAdapter
+import com.kite.app.foundation.contracts.ContainerRecord
+import org.json.JSONObject
+
+internal class CodexOfficialAccountAdapter(
+    containerProvider: () -> ContainerRecord?,
+    private val fileStore: AtomicConfigFileStore,
+) : AgentOfficialAccountAdapter {
+    private val projection = ContainerAgentConfigProjection(containerProvider)
+
+    override val adapterId: String = CodexAgentConfigAdapter.ADAPTER_ID
+
+    override fun accountCapabilities(): AgentAccountCapabilities = AgentAccountCapabilities(
+        supported = setOf(
+            AgentAccountCapability.SaveCurrent,
+            AgentAccountCapability.Switch,
+            AgentAccountCapability.Delete,
+            AgentAccountCapability.StableId,
+        ),
+    )
+
+    override suspend fun currentIdentity(agentId: String): AgentAccountIdentityResult = runCatching {
+        val bytes = readAuthBytes()
+            ?: return@runCatching AgentAccountIdentityResult.Unavailable("Codex 官方登录尚未生成原生凭据")
+        val accountId = codexAccountId(bytes)
+            ?: return@runCatching AgentAccountIdentityResult.Unavailable("Codex 没有提供稳定账号 ID")
+        codexIdentity(accountId).let(AgentAccountIdentityResult::Ready)
+    }.getOrElse { error ->
+        AgentAccountIdentityResult.Failed(error.message ?: "无法读取 Codex 官方账号状态")
+    }
+
+    override suspend fun captureCurrent(agentId: String): AgentAccountCredentialReadResult = runCatching {
+        val bytes = readAuthBytes()
+            ?: return@runCatching AgentAccountCredentialReadResult.Missing()
+        val accountId = codexAccountId(bytes)
+            ?: return@runCatching AgentAccountCredentialReadResult.Unavailable("Codex 凭据缺少稳定账号 ID")
+        AgentAccountCredentialReadResult.Ready(
+            snapshot = AgentAccountCredentialSnapshot(bytes.copyOf()),
+            identity = codexIdentity(accountId),
+        )
+    }.getOrElse { error ->
+        AgentAccountCredentialReadResult.Failed(error.message ?: "无法读取 Codex 官方凭据")
+    }
+
+    override suspend fun restoreCurrent(
+        agentId: String,
+        snapshot: AgentAccountCredentialSnapshot,
+    ): AgentAccountCredentialWriteResult {
+        val target = projection.resolve(AUTH_PATH)?.writeFile
+            ?: return AgentAccountCredentialWriteResult.Unavailable("Kite 运行容器尚未创建")
+        val before = runCatching { fileStore.read(target) }.getOrElse { error ->
+            return AgentAccountCredentialWriteResult.Failed(
+                error.message ?: "无法读取 Codex 原生凭据",
+                restored = false,
+            )
+        }
+        return when (
+            val result = fileStore.replace(
+                target = target,
+                expectedRevision = before.revision,
+                nextBytes = snapshot.bytes.copyOf(),
+                validate = ::validateAuthBytes,
+            )
+        ) {
+            is AtomicConfigFileWriteResult.Applied -> AgentAccountCredentialWriteResult.Applied
+            is AtomicConfigFileWriteResult.Conflict ->
+                AgentAccountCredentialWriteResult.Failed("Codex 原生凭据在切换期间发生变化", restored = false)
+            is AtomicConfigFileWriteResult.Rejected ->
+                AgentAccountCredentialWriteResult.Failed(result.message, restored = false)
+            is AtomicConfigFileWriteResult.Failed ->
+                AgentAccountCredentialWriteResult.Failed(result.message, result.restored)
+        }
+    }
+
+    private fun readAuthBytes(): ByteArray? = projection.resolve(AUTH_PATH)
+        ?.readFile
+        ?.let(fileStore::read)
+        ?.bytes
+        ?.takeIf { it.isNotEmpty() }
+
+    private fun codexAccountId(bytes: ByteArray): String? = runCatching {
+        val root = JSONObject(bytes.toString(Charsets.UTF_8))
+        val tokens = root.optJSONObject("tokens")
+        listOf(
+            root.optString("account_id"),
+            root.optString("accountId"),
+            tokens?.optString("account_id").orEmpty(),
+            tokens?.optString("accountId").orEmpty(),
+            tokens?.optString("chatgpt_account_id").orEmpty(),
+        ).firstOrNull { value ->
+            value.isNotBlank() && value.length <= MAX_ACCOUNT_ID && value.none(Char::isISOControl)
+        }
+    }.getOrNull()
+
+    private fun validateAuthBytes(bytes: ByteArray): String? = runCatching {
+        require(bytes.isNotEmpty()) { "Codex 官方凭据不能为空" }
+        val root = JSONObject(bytes.toString(Charsets.UTF_8))
+        require(root.optJSONObject("tokens") != null) { "Codex 官方凭据格式无效" }
+        require(codexAccountId(bytes) != null) { "Codex 官方凭据缺少稳定账号 ID" }
+        null
+    }.getOrElse { error -> error.message ?: "Codex 官方凭据格式无效" }
+
+    private fun codexIdentity(accountId: String): AgentAccountIdentity = AgentAccountIdentity(
+        accountId = accountId,
+        displayName = "ChatGPT · ${compactAccountId(accountId)}",
+    )
+
+    private fun compactAccountId(accountId: String): String =
+        if (accountId.length <= 12) accountId else "${accountId.take(6)}…${accountId.takeLast(4)}"
+
+    private companion object {
+        const val AUTH_PATH = "/root/.codex/auth.json"
+        const val MAX_ACCOUNT_ID = 256
+    }
+}

--- a/app/src/main/java/com/kite/app/agent/sdk/account/AgentAccountContract.kt
+++ b/app/src/main/java/com/kite/app/agent/sdk/account/AgentAccountContract.kt
@@ -63,6 +63,7 @@ internal interface AgentOfficialAccountAdapter {
 
     fun accountCapabilities(): AgentAccountCapabilities
 
+    /** 只读取 Agent 本地原生状态；账号管理操作不得借此发起联网验证。 */
     suspend fun currentIdentity(agentId: String): AgentAccountIdentityResult
 
     suspend fun captureCurrent(agentId: String): AgentAccountCredentialReadResult

--- a/app/src/main/java/com/kite/app/agent/sdk/account/AgentAccountContract.kt
+++ b/app/src/main/java/com/kite/app/agent/sdk/account/AgentAccountContract.kt
@@ -1,0 +1,70 @@
+package com.kite.app.agent.sdk.account
+
+/**
+ * Agent 官方账号能力的统一边界。
+ *
+ * UI 和 SDK 只处理账号意图、稳定 ID 以及非敏感元数据；原生凭据快照只在账号协调器和
+ * Agent Adapter 之间短暂流转，不提供给页面状态、日志或 Provider 目录。
+ */
+internal enum class AgentAccountCapability {
+    SaveCurrent,
+    Switch,
+    Delete,
+    StableId,
+}
+
+internal data class AgentAccountCapabilities(
+    val supported: Set<AgentAccountCapability>,
+) {
+    fun supports(capability: AgentAccountCapability): Boolean = capability in supported
+}
+
+internal data class AgentAccountIdentity(
+    val accountId: String,
+    val displayName: String,
+)
+
+/** 不透明的 Agent 原生凭据快照；toString 永远不包含凭据内容。 */
+internal class AgentAccountCredentialSnapshot internal constructor(
+    val bytes: ByteArray,
+) {
+    override fun toString(): String =
+        "AgentAccountCredentialSnapshot(size=${bytes.size})"
+}
+
+internal sealed interface AgentAccountIdentityResult {
+    data class Ready(val identity: AgentAccountIdentity) : AgentAccountIdentityResult
+    data class Unavailable(val message: String) : AgentAccountIdentityResult
+    data class Failed(val message: String) : AgentAccountIdentityResult
+}
+
+internal sealed interface AgentAccountCredentialReadResult {
+    data class Ready(val snapshot: AgentAccountCredentialSnapshot) : AgentAccountCredentialReadResult
+    data class Missing(val message: String = "当前 Agent 没有可保存的官方凭据") : AgentAccountCredentialReadResult
+    data class Unavailable(val message: String) : AgentAccountCredentialReadResult
+    data class Failed(val message: String) : AgentAccountCredentialReadResult
+}
+
+internal sealed interface AgentAccountCredentialWriteResult {
+    data object Applied : AgentAccountCredentialWriteResult
+    data class Unavailable(val message: String) : AgentAccountCredentialWriteResult
+    data class Failed(val message: String, val restored: Boolean) : AgentAccountCredentialWriteResult
+}
+
+/**
+ * 具体 Agent 拥有真实凭据位置和文件格式；Kite 不在 UI 或公共 Provider API 中处理这些内容。
+ */
+internal interface AgentOfficialAccountAdapter {
+    val adapterId: String
+
+    fun accountCapabilities(): AgentAccountCapabilities
+
+    suspend fun currentIdentity(agentId: String): AgentAccountIdentityResult
+
+    suspend fun captureCurrent(agentId: String): AgentAccountCredentialReadResult
+
+    suspend fun restoreCurrent(
+        agentId: String,
+        snapshot: AgentAccountCredentialSnapshot,
+    ): AgentAccountCredentialWriteResult
+}

--- a/app/src/main/java/com/kite/app/agent/sdk/account/AgentAccountContract.kt
+++ b/app/src/main/java/com/kite/app/agent/sdk/account/AgentAccountContract.kt
@@ -39,7 +39,11 @@ internal sealed interface AgentAccountIdentityResult {
 }
 
 internal sealed interface AgentAccountCredentialReadResult {
-    data class Ready(val snapshot: AgentAccountCredentialSnapshot) : AgentAccountCredentialReadResult
+    /** 身份与凭据必须来自同一次原生快照，避免账号在两次读取之间变化。 */
+    data class Ready(
+        val snapshot: AgentAccountCredentialSnapshot,
+        val identity: AgentAccountIdentity,
+    ) : AgentAccountCredentialReadResult
     data class Missing(val message: String = "当前 Agent 没有可保存的官方凭据") : AgentAccountCredentialReadResult
     data class Unavailable(val message: String) : AgentAccountCredentialReadResult
     data class Failed(val message: String) : AgentAccountCredentialReadResult

--- a/app/src/main/java/com/kite/app/feature/runsurface/RunAgentSurfaceBinding.kt
+++ b/app/src/main/java/com/kite/app/feature/runsurface/RunAgentSurfaceBinding.kt
@@ -105,8 +105,11 @@ import com.kite.app.agent.registration.AgentRegistryEntry
 import com.kite.app.agent.registration.AgentRegistrySnapshot
 import com.kite.app.agent.registration.AgentRuntimeStatus
 import com.kite.app.agent.registration.KiteAgentRegistry
+import com.kite.app.agent.auth.AgentOfficialAccountOperationResult
 import com.kite.app.agent.auth.AgentOfficialAccountManager
+import com.kite.app.agent.auth.AgentSavedOfficialAccount
 import com.kite.app.agent.auth.AgentOfficialAccountStatus
+import com.kite.app.agent.sdk.account.AgentAccountCapability
 import com.kite.app.agent.runtime.AgentDraftCapabilityCatalog
 import com.kite.app.agent.runtime.AgentDraftModelSelection
 import com.kite.app.agent.sdk.configuration.AgentConfigurationApi
@@ -151,6 +154,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
@@ -3684,11 +3688,26 @@ internal class RunAgentSurfaceBinding(
         if (officialAccountObservedAgentId != targetAgentId) {
             officialAccountObservation?.cancel()
             officialAccountObservedAgentId = targetAgentId
-            var previous = officialAccountManager.states.value.filterKeys { it.agentId == targetAgentId }
+            officialAccountManager.loadSavedAccounts(targetAgentId)
+            var previous = Triple(
+                officialAccountManager.states.value.filterKeys { it.agentId == targetAgentId },
+                officialAccountManager.savedAccounts.value[targetAgentId].orEmpty(),
+                officialAccountManager.currentAccountIds.value[targetAgentId],
+            )
             officialAccountObservation = lifecycleOwner.lifecycleScope.launch {
                 lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                    officialAccountManager.states.collect { allStates ->
-                        val relevant = allStates.filterKeys { it.agentId == targetAgentId }
+                    combine(
+                        officialAccountManager.states,
+                        officialAccountManager.savedAccounts,
+                        officialAccountManager.currentAccountIds,
+                    ) { allStates, allSaved, allCurrent ->
+                        Triple(
+                            allStates.filterKeys { it.agentId == targetAgentId },
+                            allSaved[targetAgentId].orEmpty(),
+                            allCurrent[targetAgentId],
+                        )
+                    }.collect { (relevantStates, relevantSaved, relevantCurrent) ->
+                        val relevant = Triple(relevantStates, relevantSaved, relevantCurrent)
                         if (relevant == previous) return@collect
                         previous = relevant
                         if (
@@ -6300,45 +6319,181 @@ internal class RunAgentSurfaceBinding(
         agentId: String,
         account: com.kite.app.agent.registration.AgentOfficialAccountSpec,
         status: AgentOfficialAccountStatus,
-    ): TextView = TextView(context).apply {
-        text = when (status) {
-            AgentOfficialAccountStatus.Checking -> "检查中"
-            AgentOfficialAccountStatus.SigningIn -> "取消"
-            AgentOfficialAccountStatus.CancellingLogin -> "取消中"
-            AgentOfficialAccountStatus.SigningOut -> "退出中"
-            AgentOfficialAccountStatus.LoggedIn -> if (account.logout != null) "退出" else "已登录"
-            AgentOfficialAccountStatus.Unknown,
-            AgentOfficialAccountStatus.Unverified,
-            AgentOfficialAccountStatus.LoggedOut,
-            AgentOfficialAccountStatus.Failed -> "登录"
+    ): View = LinearLayout(context).apply {
+        orientation = LinearLayout.HORIZONTAL
+        gravity = Gravity.CENTER_VERTICAL
+
+        fun actionButton(
+            label: String,
+            enabled: Boolean = true,
+            onClick: () -> Unit,
+        ): TextView = TextView(context).apply {
+            text = label
+            textSize = 14f
+            typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+            gravity = Gravity.CENTER
+            setTextColor(tokens.textPrimary)
+            setPadding(ui.dp(13), 0, ui.dp(13), 0)
+            background = ui.roundedBox(
+                agentSurface,
+                tokens.border,
+                ui.dp(18).toFloat(),
+                ui.dp(1),
+            )
+            isEnabled = enabled
+            alpha = if (enabled) 1f else 0.55f
+            isClickable = enabled
+            isFocusable = enabled
+            setOnClickListener { onClick() }
         }
-        textSize = 14f
-        typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
-        gravity = Gravity.CENTER
-        setTextColor(tokens.textPrimary)
-        setPadding(ui.dp(13), 0, ui.dp(13), 0)
-        background = ui.roundedBox(
-            agentSurface,
-            tokens.border,
-            ui.dp(18).toFloat(),
-            ui.dp(1),
-        )
+
         val pending = status in setOf(
             AgentOfficialAccountStatus.Checking,
             AgentOfficialAccountStatus.CancellingLogin,
             AgentOfficialAccountStatus.SigningOut,
+            AgentOfficialAccountStatus.Saving,
+            AgentOfficialAccountStatus.Switching,
+            AgentOfficialAccountStatus.Deleting,
         )
-        isEnabled = !pending && (status != AgentOfficialAccountStatus.LoggedIn || account.logout != null)
-        alpha = if (isEnabled) 1f else 0.55f
-        isClickable = isEnabled
-        isFocusable = isEnabled
-        setOnClickListener {
-            when (status) {
-                AgentOfficialAccountStatus.SigningIn -> officialAccountManager.cancelLogin(agentId, account.id)
-                AgentOfficialAccountStatus.LoggedIn -> officialAccountManager.logout(agentId, account.id)
-                else -> officialAccountManager.login(agentId, account.id)
-            }
+        val primaryEnabled = !pending && (status != AgentOfficialAccountStatus.LoggedIn || account.logout != null)
+        addView(
+            actionButton(
+                label = when (status) {
+                    AgentOfficialAccountStatus.Checking -> "检查中"
+                    AgentOfficialAccountStatus.SigningIn -> "取消"
+                    AgentOfficialAccountStatus.CancellingLogin -> "取消中"
+                    AgentOfficialAccountStatus.SigningOut -> "退出中"
+                    AgentOfficialAccountStatus.Saving -> "保存中"
+                    AgentOfficialAccountStatus.Switching -> "切换中"
+                    AgentOfficialAccountStatus.Deleting -> "删除中"
+                    AgentOfficialAccountStatus.LoggedIn -> if (account.logout != null) "退出" else "已登录"
+                    AgentOfficialAccountStatus.Unknown,
+                    AgentOfficialAccountStatus.Unverified,
+                    AgentOfficialAccountStatus.LoggedOut,
+                    AgentOfficialAccountStatus.Failed -> "登录"
+                },
+                enabled = primaryEnabled,
+            ) {
+                when (status) {
+                    AgentOfficialAccountStatus.SigningIn -> officialAccountManager.cancelLogin(agentId, account.id)
+                    AgentOfficialAccountStatus.LoggedIn -> officialAccountManager.logout(agentId, account.id)
+                    else -> officialAccountManager.login(agentId, account.id)
+                }
+            },
+            LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ui.dp(36)),
+        )
+
+        val capabilities = officialAccountManager.accountCapabilities(agentId)
+        val savedAccounts = officialAccountManager.savedAccounts(agentId)
+        if (status == AgentOfficialAccountStatus.LoggedIn &&
+            capabilities?.supports(AgentAccountCapability.SaveCurrent) == true
+        ) {
+            addView(
+                actionButton("保存", enabled = !pending) {
+                    officialAccountManager.saveCurrent(agentId, account.id) { result ->
+                        lifecycleOwner.lifecycleScope.launch {
+                            Toast.makeText(context, result.accountOperationMessage(), Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                },
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ui.dp(36)).apply {
+                    marginStart = ui.dp(6)
+                },
+            )
         }
+        if (savedAccounts.isNotEmpty() &&
+            capabilities?.supports(AgentAccountCapability.Switch) == true
+        ) {
+            addView(
+                actionButton("账号", enabled = !pending) {
+                    showSavedOfficialAccounts(agentId, account)
+                },
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ui.dp(36)).apply {
+                    marginStart = ui.dp(6)
+                },
+            )
+        }
+    }
+
+    private fun AgentOfficialAccountOperationResult.accountOperationMessage(): String = when (this) {
+        is AgentOfficialAccountOperationResult.Saved -> "已保存 ${account.displayName}"
+        is AgentOfficialAccountOperationResult.Switched -> "已切换到 ${account.displayName}"
+        AgentOfficialAccountOperationResult.Deleted -> "已删除账号档案"
+        is AgentOfficialAccountOperationResult.Unsupported -> message
+        is AgentOfficialAccountOperationResult.Failed -> if (restored) {
+            "$message，已回滚"
+        } else {
+            message
+        }
+    }
+
+    private fun showSavedOfficialAccounts(
+        agentId: String,
+        loginAccount: AgentOfficialAccountSpec,
+    ) {
+        val accounts = officialAccountManager.savedAccounts(agentId)
+        if (accounts.isEmpty()) {
+            Toast.makeText(context, "还没有保存的官方账号", Toast.LENGTH_SHORT).show()
+            return
+        }
+        val currentId = officialAccountManager.currentSavedAccountId(agentId)
+        showAgentChoiceCard(
+            title = "官方账号",
+            message = "账号由 Agent 官方登录流程生成；选择一个档案后可以切换或删除。",
+            actions = accounts.map { saved ->
+                AgentChoiceAction(
+                    label = saved.displayName,
+                    selected = saved.accountId == currentId,
+                    onClick = { showSavedOfficialAccountActions(agentId, loginAccount, saved) },
+                )
+            },
+        )
+    }
+
+    private fun showSavedOfficialAccountActions(
+        agentId: String,
+        loginAccount: AgentOfficialAccountSpec,
+        saved: AgentSavedOfficialAccount,
+    ) {
+        val currentId = officialAccountManager.currentSavedAccountId(agentId)
+        val isCurrent = currentId == saved.accountId
+        showAgentDialogCard(
+            title = saved.displayName,
+            message = if (isCurrent) {
+                "这是当前 Agent 正在使用的账号。请先切换到其他账号后再删除。"
+            } else {
+                "切换会先保存当前 Agent 的最新原生凭据；验证失败时会自动回滚。"
+            },
+            actions = listOf(
+                AgentDialogAction("取消", UiActionRole.Secondary) { dialog, _ -> dialog.dismiss() },
+                AgentDialogAction("切换", UiActionRole.Primary, enabled = !isCurrent) { dialog, _ ->
+                    dialog.dismiss()
+                    officialAccountManager.switchTo(agentId, loginAccount.id, saved.accountId) { result ->
+                        lifecycleOwner.lifecycleScope.launch {
+                            Toast.makeText(context, result.accountOperationMessage(), Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                },
+                AgentDialogAction("删除", UiActionRole.Danger, enabled = !isCurrent) { dialog, _ ->
+                    dialog.dismiss()
+                    showAgentDialogCard(
+                        title = "删除账号档案？",
+                        message = "只会删除 Kite 保存的加密档案，不会读取或导出 Token。",
+                        actions = listOf(
+                            AgentDialogAction("取消", UiActionRole.Secondary) { confirm, _ -> confirm.dismiss() },
+                            AgentDialogAction("删除", UiActionRole.Danger) { confirm, _ ->
+                                confirm.dismiss()
+                                officialAccountManager.deleteSaved(agentId, loginAccount.id, saved.accountId) { result ->
+                                    lifecycleOwner.lifecycleScope.launch {
+                                        Toast.makeText(context, result.accountOperationMessage(), Toast.LENGTH_SHORT).show()
+                                    }
+                                }
+                            },
+                        ),
+                    )
+                },
+            ),
+        )
     }
 
     private fun AgentOfficialAccountStatus.officialAccountLabel(): String = when (this) {
@@ -6350,6 +6505,9 @@ internal class RunAgentSurfaceBinding(
         AgentOfficialAccountStatus.SigningIn -> "等待浏览器确认"
         AgentOfficialAccountStatus.CancellingLogin -> "正在结束登录"
         AgentOfficialAccountStatus.SigningOut -> "正在退出"
+        AgentOfficialAccountStatus.Saving -> "正在保存账号"
+        AgentOfficialAccountStatus.Switching -> "正在切换账号"
+        AgentOfficialAccountStatus.Deleting -> "正在删除账号"
         AgentOfficialAccountStatus.Failed -> "状态未知"
     }
 

--- a/app/src/main/java/com/kite/app/shell/KiteAppGraph.kt
+++ b/app/src/main/java/com/kite/app/shell/KiteAppGraph.kt
@@ -8,6 +8,7 @@ import com.kite.app.action.KiteRecipeActionCoordinator
 import com.kite.app.agent.registration.KiteAgentRegistry
 import com.kite.app.agent.registration.KiteCustomAgentRegistrationStore
 import com.kite.app.agent.auth.AgentOfficialAccountManager
+import com.kite.app.agent.auth.AndroidAgentOfficialAccountVault
 import com.kite.app.agent.config.AgentConfigAdapterRegistry
 import com.kite.app.agent.config.AdapterBackedAgentConfigurationApi
 import com.kite.app.agent.config.defaultAgentConfigAdapters
@@ -199,7 +200,13 @@ internal class KiteAppGraph private constructor(context: Context) {
             commandRunner = AndroidAgentOfficialAccountCommandRunner(
                 context = appContext,
                 openExternal = { url -> AndroidExternalBrowserLauncher.open(appContext, url) }
-            )
+            ),
+            accountAdapterResolver = { agentId ->
+                agentRegistry.snapshot().entry(agentId)?.registration?.let { registration ->
+                    agentConfigAdapterRegistry.officialAccountAdapterFor(registration)
+                }
+            },
+            vault = AndroidAgentOfficialAccountVault(appContext),
         )
     }
     val recipeLoader: KiteRecipeLoader by lazy { KiteRecipeLoader(appContext, diagnostics) }

--- a/app/src/test/kotlin/com/kite/app/agent/auth/AgentOfficialAccountManagerTest.kt
+++ b/app/src/test/kotlin/com/kite/app/agent/auth/AgentOfficialAccountManagerTest.kt
@@ -256,6 +256,36 @@ class AgentOfficialAccountManagerTest {
         assertEquals(listOf("first"), vault.accounts(AGENT_ID).map { it.accountId })
     }
 
+    @Test
+    fun `原生账号变化后不能依赖过期标记删除真实当前档案`() = runTest {
+        val dispatcher = kotlinx.coroutines.test.StandardTestDispatcher(testScheduler)
+        val vault = MemoryOfficialAccountVault()
+        val adapter = FakeOfficialAccountAdapter()
+        val manager = AgentOfficialAccountManager(
+            scope = this,
+            registry = registry(),
+            commandRunner = { AgentOfficialAccountCommandResult(0, "Logged in") },
+            accountAdapterResolver = { adapter },
+            vault = vault,
+            storageDispatcher = dispatcher,
+        )
+        manager.saveCurrent(AGENT_ID, ACCOUNT_ID)
+        advanceUntilIdle()
+        adapter.useAccount("second")
+        manager.saveCurrent(AGENT_ID, ACCOUNT_ID)
+        advanceUntilIdle()
+        assertEquals("second", vault.currentAccountId(AGENT_ID))
+
+        adapter.useAccount("first", "refreshed")
+        val results = mutableListOf<AgentOfficialAccountOperationResult>()
+        manager.deleteSaved(AGENT_ID, ACCOUNT_ID, "first") { results += it }
+        advanceUntilIdle()
+
+        assertTrue(results.last() is AgentOfficialAccountOperationResult.Failed)
+        assertEquals(listOf("first", "second"), vault.accounts(AGENT_ID).map { it.accountId }.sorted())
+        assertEquals("first", vault.currentAccountId(AGENT_ID))
+    }
+
     private fun registry(): KiteAgentRegistry {
         val context = ApplicationProvider.getApplicationContext<Context>()
         return KiteAgentRegistry(

--- a/app/src/test/kotlin/com/kite/app/agent/auth/AgentOfficialAccountManagerTest.kt
+++ b/app/src/test/kotlin/com/kite/app/agent/auth/AgentOfficialAccountManagerTest.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -115,6 +116,7 @@ class AgentOfficialAccountManagerTest {
         assertEquals(2, vault.accounts(AGENT_ID).size)
         assertEquals("second", vault.currentAccountId(AGENT_ID))
 
+        adapter.useAccount("second", "refreshed")
         adapter.returnWrongIdentityOnce = true
         manager.switchTo(AGENT_ID, ACCOUNT_ID, "first") { results += it }
         advanceUntilIdle()
@@ -122,7 +124,103 @@ class AgentOfficialAccountManagerTest {
         val failure = results.last() as AgentOfficialAccountOperationResult.Failed
         assertTrue(failure.restored)
         assertEquals("second", adapter.currentAccountId())
+        assertEquals("native:second:refreshed", adapter.currentCredential())
+        assertArrayEquals(
+            "native:second:refreshed".toByteArray(),
+            vault.credentialBytes(AGENT_ID, "second"),
+        )
         assertEquals("second", vault.currentAccountId(AGENT_ID))
+    }
+
+    @Test
+    fun `切换前用最新原生凭据更新当前已保存账号`() = runTest {
+        val dispatcher = kotlinx.coroutines.test.StandardTestDispatcher(testScheduler)
+        val vault = MemoryOfficialAccountVault()
+        val adapter = FakeOfficialAccountAdapter()
+        val manager = AgentOfficialAccountManager(
+            scope = this,
+            registry = registry(),
+            commandRunner = { AgentOfficialAccountCommandResult(0, "Logged in") },
+            accountAdapterResolver = { adapter },
+            vault = vault,
+            storageDispatcher = dispatcher,
+        )
+
+        manager.saveCurrent(AGENT_ID, ACCOUNT_ID)
+        advanceUntilIdle()
+        adapter.useAccount("second")
+        manager.saveCurrent(AGENT_ID, ACCOUNT_ID)
+        advanceUntilIdle()
+
+        adapter.useAccount("second", "refreshed")
+        manager.switchTo(AGENT_ID, ACCOUNT_ID, "first")
+        advanceUntilIdle()
+
+        assertEquals("first", adapter.currentAccountId())
+        assertEquals("first", vault.currentAccountId(AGENT_ID))
+        assertArrayEquals(
+            "native:second:refreshed".toByteArray(),
+            vault.credentialBytes(AGENT_ID, "second"),
+        )
+    }
+
+    @Test
+    fun `切换时不会为未显式保存的当前账号自动建档`() = runTest {
+        val dispatcher = kotlinx.coroutines.test.StandardTestDispatcher(testScheduler)
+        val vault = MemoryOfficialAccountVault()
+        val adapter = FakeOfficialAccountAdapter()
+        val manager = AgentOfficialAccountManager(
+            scope = this,
+            registry = registry(),
+            commandRunner = { AgentOfficialAccountCommandResult(0, "Logged in") },
+            accountAdapterResolver = { adapter },
+            vault = vault,
+            storageDispatcher = dispatcher,
+        )
+
+        manager.saveCurrent(AGENT_ID, ACCOUNT_ID)
+        advanceUntilIdle()
+        adapter.useAccount("not-saved", "fresh")
+
+        manager.switchTo(AGENT_ID, ACCOUNT_ID, "first")
+        advanceUntilIdle()
+
+        assertEquals(listOf("first"), vault.accounts(AGENT_ID).map { it.accountId })
+        assertEquals("first", adapter.currentAccountId())
+        assertEquals("first", vault.currentAccountId(AGENT_ID))
+    }
+
+    @Test
+    fun `实际账号已是目标时不会用旧档案覆盖最新凭据`() = runTest {
+        val dispatcher = kotlinx.coroutines.test.StandardTestDispatcher(testScheduler)
+        val vault = MemoryOfficialAccountVault()
+        val adapter = FakeOfficialAccountAdapter()
+        val manager = AgentOfficialAccountManager(
+            scope = this,
+            registry = registry(),
+            commandRunner = { AgentOfficialAccountCommandResult(0, "Logged in") },
+            accountAdapterResolver = { adapter },
+            vault = vault,
+            storageDispatcher = dispatcher,
+        )
+
+        manager.saveCurrent(AGENT_ID, ACCOUNT_ID)
+        advanceUntilIdle()
+        adapter.useAccount("second")
+        manager.saveCurrent(AGENT_ID, ACCOUNT_ID)
+        advanceUntilIdle()
+        assertEquals("second", vault.currentAccountId(AGENT_ID))
+
+        adapter.useAccount("first", "refreshed")
+        manager.switchTo(AGENT_ID, ACCOUNT_ID, "first")
+        advanceUntilIdle()
+
+        assertEquals("native:first:refreshed", adapter.currentCredential())
+        assertArrayEquals(
+            "native:first:refreshed".toByteArray(),
+            vault.credentialBytes(AGENT_ID, "first"),
+        )
+        assertEquals("first", vault.currentAccountId(AGENT_ID))
     }
 
     @Test
@@ -213,6 +311,9 @@ private class MemoryOfficialAccountVault : AgentOfficialAccountVault {
     override fun credential(agentId: String, accountId: String): AgentAccountCredentialSnapshot? =
         records[agentId to accountId]?.second?.let { AgentAccountCredentialSnapshot(it.copyOf()) }
 
+    fun credentialBytes(agentId: String, accountId: String): ByteArray? =
+        records[agentId to accountId]?.second?.copyOf()
+
     override fun markCurrent(agentId: String, accountId: String) {
         currentIds[agentId] = accountId
     }
@@ -237,7 +338,7 @@ private class FakeOfficialAccountAdapter : AgentOfficialAccountAdapter {
     )
 
     override suspend fun currentIdentity(agentId: String): AgentAccountIdentityResult {
-        val actual = bytes.toString(Charsets.UTF_8).removePrefix("native:")
+        val actual = accountId(bytes)
         if (returnWrongIdentityOnce) {
             returnWrongIdentityOnce = false
             return AgentAccountIdentityResult.Ready(AgentAccountIdentity("unexpected", "Unexpected"))
@@ -246,7 +347,10 @@ private class FakeOfficialAccountAdapter : AgentOfficialAccountAdapter {
     }
 
     override suspend fun captureCurrent(agentId: String): AgentAccountCredentialReadResult =
-        AgentAccountCredentialReadResult.Ready(AgentAccountCredentialSnapshot(bytes.copyOf()))
+        AgentAccountCredentialReadResult.Ready(
+            snapshot = AgentAccountCredentialSnapshot(bytes.copyOf()),
+            identity = AgentAccountIdentity(accountId(bytes), "Official ${accountId(bytes)}"),
+        )
 
     override suspend fun restoreCurrent(
         agentId: String,
@@ -256,9 +360,14 @@ private class FakeOfficialAccountAdapter : AgentOfficialAccountAdapter {
         return AgentAccountCredentialWriteResult.Applied
     }
 
-    fun useAccount(accountId: String) {
-        bytes = "native:$accountId".toByteArray()
+    fun useAccount(accountId: String, credentialVersion: String? = null) {
+        bytes = listOfNotNull("native", accountId, credentialVersion).joinToString(":").toByteArray()
     }
 
-    fun currentAccountId(): String = bytes.toString(Charsets.UTF_8).removePrefix("native:")
+    fun currentAccountId(): String = accountId(bytes)
+
+    fun currentCredential(): String = bytes.toString(Charsets.UTF_8)
+
+    private fun accountId(snapshot: ByteArray): String =
+        snapshot.toString(Charsets.UTF_8).removePrefix("native:").substringBefore(':')
 }

--- a/app/src/test/kotlin/com/kite/app/agent/auth/AgentOfficialAccountManagerTest.kt
+++ b/app/src/test/kotlin/com/kite/app/agent/auth/AgentOfficialAccountManagerTest.kt
@@ -9,6 +9,14 @@ import com.kite.app.agent.registration.AgentOfficialAccountSpec
 import com.kite.app.agent.registration.AgentRegistration
 import com.kite.app.agent.registration.AgentRegistrationSource
 import com.kite.app.agent.registration.KiteAgentRegistry
+import com.kite.app.agent.sdk.account.AgentAccountCapabilities
+import com.kite.app.agent.sdk.account.AgentAccountCapability
+import com.kite.app.agent.sdk.account.AgentAccountCredentialReadResult
+import com.kite.app.agent.sdk.account.AgentAccountCredentialSnapshot
+import com.kite.app.agent.sdk.account.AgentAccountCredentialWriteResult
+import com.kite.app.agent.sdk.account.AgentAccountIdentity
+import com.kite.app.agent.sdk.account.AgentAccountIdentityResult
+import com.kite.app.agent.sdk.account.AgentOfficialAccountAdapter
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.awaitCancellation
@@ -16,6 +24,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -79,6 +88,76 @@ class AgentOfficialAccountManagerTest {
         assertEquals(AgentOfficialAccountStatus.LoggedIn, manager.state(AGENT_ID, ACCOUNT_ID).status)
     }
 
+    @Test
+    fun `保存并切换账号在验证失败时回滚原生凭据`() = runTest {
+        val dispatcher = kotlinx.coroutines.test.StandardTestDispatcher(testScheduler)
+        val vault = MemoryOfficialAccountVault()
+        val adapter = FakeOfficialAccountAdapter()
+        val manager = AgentOfficialAccountManager(
+            scope = this,
+            registry = registry(),
+            commandRunner = { AgentOfficialAccountCommandResult(0, "Logged in") },
+            accountAdapterResolver = { adapter },
+            vault = vault,
+            storageDispatcher = dispatcher,
+        )
+        val results = mutableListOf<AgentOfficialAccountOperationResult>()
+
+        manager.saveCurrent(AGENT_ID, ACCOUNT_ID) { results += it }
+        advanceUntilIdle()
+        assertTrue(results.last() is AgentOfficialAccountOperationResult.Saved)
+        assertEquals("first", vault.currentAccountId(AGENT_ID))
+
+        adapter.useAccount("second")
+        manager.saveCurrent(AGENT_ID, ACCOUNT_ID) { results += it }
+        advanceUntilIdle()
+        assertTrue(results.last() is AgentOfficialAccountOperationResult.Saved)
+        assertEquals(2, vault.accounts(AGENT_ID).size)
+        assertEquals("second", vault.currentAccountId(AGENT_ID))
+
+        adapter.returnWrongIdentityOnce = true
+        manager.switchTo(AGENT_ID, ACCOUNT_ID, "first") { results += it }
+        advanceUntilIdle()
+
+        val failure = results.last() as AgentOfficialAccountOperationResult.Failed
+        assertTrue(failure.restored)
+        assertEquals("second", adapter.currentAccountId())
+        assertEquals("second", vault.currentAccountId(AGENT_ID))
+    }
+
+    @Test
+    fun `不能删除当前账号切换后可以删除旧档案`() = runTest {
+        val dispatcher = kotlinx.coroutines.test.StandardTestDispatcher(testScheduler)
+        val vault = MemoryOfficialAccountVault()
+        val adapter = FakeOfficialAccountAdapter()
+        val manager = AgentOfficialAccountManager(
+            scope = this,
+            registry = registry(),
+            commandRunner = { AgentOfficialAccountCommandResult(0, "Logged in") },
+            accountAdapterResolver = { adapter },
+            vault = vault,
+            storageDispatcher = dispatcher,
+        )
+        adapter.useAccount("first")
+        manager.saveCurrent(AGENT_ID, ACCOUNT_ID)
+        advanceUntilIdle()
+        adapter.useAccount("second")
+        manager.saveCurrent(AGENT_ID, ACCOUNT_ID)
+        advanceUntilIdle()
+
+        val results = mutableListOf<AgentOfficialAccountOperationResult>()
+        manager.deleteSaved(AGENT_ID, ACCOUNT_ID, "second") { results += it }
+        advanceUntilIdle()
+        assertTrue(results.last() is AgentOfficialAccountOperationResult.Failed)
+
+        manager.switchTo(AGENT_ID, ACCOUNT_ID, "first") { results += it }
+        advanceUntilIdle()
+        manager.deleteSaved(AGENT_ID, ACCOUNT_ID, "second") { results += it }
+        advanceUntilIdle()
+        assertEquals(AgentOfficialAccountOperationResult.Deleted, results.last())
+        assertEquals(listOf("first"), vault.accounts(AGENT_ID).map { it.accountId })
+    }
+
     private fun registry(): KiteAgentRegistry {
         val context = ApplicationProvider.getApplicationContext<Context>()
         return KiteAgentRegistry(
@@ -111,4 +190,75 @@ class AgentOfficialAccountManagerTest {
         const val AGENT_ID = "kimi"
         const val ACCOUNT_ID = "moonshot"
     }
+}
+
+private class MemoryOfficialAccountVault : AgentOfficialAccountVault {
+    private val records = linkedMapOf<Pair<String, String>, Pair<AgentSavedOfficialAccount, ByteArray>>()
+    private val currentIds = mutableMapOf<String, String>()
+
+    override fun accounts(agentId: String): List<AgentSavedOfficialAccount> = records.values
+        .map { it.first }
+        .filter { it.agentId == agentId }
+        .sortedByDescending(AgentSavedOfficialAccount::lastUsedAt)
+
+    override fun account(agentId: String, accountId: String): AgentSavedOfficialAccount? =
+        records[agentId to accountId]?.first
+
+    override fun currentAccountId(agentId: String): String? = currentIds[agentId]
+
+    override fun save(account: AgentSavedOfficialAccount, credential: AgentAccountCredentialSnapshot) {
+        records[account.agentId to account.accountId] = account to credential.bytes.copyOf()
+    }
+
+    override fun credential(agentId: String, accountId: String): AgentAccountCredentialSnapshot? =
+        records[agentId to accountId]?.second?.let { AgentAccountCredentialSnapshot(it.copyOf()) }
+
+    override fun markCurrent(agentId: String, accountId: String) {
+        currentIds[agentId] = accountId
+    }
+
+    override fun remove(agentId: String, accountId: String) {
+        records.remove(agentId to accountId)
+    }
+}
+
+private class FakeOfficialAccountAdapter : AgentOfficialAccountAdapter {
+    override val adapterId: String = "fake"
+    private var bytes = "native:first".toByteArray()
+    var returnWrongIdentityOnce: Boolean = false
+
+    override fun accountCapabilities(): AgentAccountCapabilities = AgentAccountCapabilities(
+        setOf(
+            AgentAccountCapability.SaveCurrent,
+            AgentAccountCapability.Switch,
+            AgentAccountCapability.Delete,
+            AgentAccountCapability.StableId,
+        )
+    )
+
+    override suspend fun currentIdentity(agentId: String): AgentAccountIdentityResult {
+        val actual = bytes.toString(Charsets.UTF_8).removePrefix("native:")
+        if (returnWrongIdentityOnce) {
+            returnWrongIdentityOnce = false
+            return AgentAccountIdentityResult.Ready(AgentAccountIdentity("unexpected", "Unexpected"))
+        }
+        return AgentAccountIdentityResult.Ready(AgentAccountIdentity(actual, "Official $actual"))
+    }
+
+    override suspend fun captureCurrent(agentId: String): AgentAccountCredentialReadResult =
+        AgentAccountCredentialReadResult.Ready(AgentAccountCredentialSnapshot(bytes.copyOf()))
+
+    override suspend fun restoreCurrent(
+        agentId: String,
+        snapshot: AgentAccountCredentialSnapshot,
+    ): AgentAccountCredentialWriteResult {
+        bytes = snapshot.bytes.copyOf()
+        return AgentAccountCredentialWriteResult.Applied
+    }
+
+    fun useAccount(accountId: String) {
+        bytes = "native:$accountId".toByteArray()
+    }
+
+    fun currentAccountId(): String = bytes.toString(Charsets.UTF_8).removePrefix("native:")
 }


### PR DESCRIPTION
## 变更概览

这是一个基于官方登录流程的账号档案管理版本，先实现通用边界，再由具体 Agent Adapter 声明能力。

- 官方登录、登出、状态检查仍使用 Agent 原生命令，不导入外部 Token/JSON 凭据。
- 登录成功后可保存当前官方账号；Codex 适配器从原生 auth.json 读取稳定账号 ID。
- Android Keystore 生成 AES-GCM 主密钥，SQLite 分开保存账号元数据和加密原生凭据。
- 支持切换、删除非当前账号；切换前捕获当前原生凭据，目标身份校验失败时自动回滚。
- 原生文件写入继续经过现有 AtomicConfigFileStore，并保留版本冲突保护和验证。
- 页面只展示账号元数据和动作状态，不把凭据内容放入 UI、Provider 目录或日志。

## 验证

- `:app:compileDebugKotlin`：通过
- `:app:assembleDebug`：通过
- 新增账号保存/切换回滚/删除保护测试
- 当前仓库全量 Unit Test 在编译既有 `ResourceVersionBatchSchedulingCandidateTest` 时被主线缺失类型阻塞，尚未进入测试执行；本 PR 未修改该既有测试。
- 当前 USB 设备列表为空，因此未进行真机安装启动检查。

关联设计讨论：#13、#10